### PR TITLE
[Chore/#8] Recruit Header Dday

### DIFF
--- a/src/components/recruit/recuritHeader/RecuritHeader.tsx
+++ b/src/components/recruit/recuritHeader/RecuritHeader.tsx
@@ -3,8 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { Spinner } from 'reactstrap';
 import { THIS_SEASON } from '../../../constants/common';
 import RecruitModal from '../recruitModal/RecruitModal';
-import RecruitUnivScrolling from '../recruitUnivScrolling/RecruitUnivScrolling';
-import * as S from './style';
 import styles from './RecruitHeader.module.scss';
 import classNames from 'classnames/bind';
 import { Button, Text } from '@goorm-dev/vapor-components';
@@ -12,118 +10,172 @@ import { TYPOGRAPHY } from '@goorm-dev/vapor-components/dist/types/src/component
 
 const cx = classNames.bind(styles);
 
+const REP_START_DATE = new Date('2024-08-10T10:00:00');
+const REP_END_DATE = new Date('2024-08-25T10:00:00');
+const TEAM_START_DATE = new Date('2024-08-01T10:00:00');
+const TEAM_END_DATE = new Date('2024-08-15T10:00:00');
+const REP_START_ONE_WEEK_BEFORE = new Date(REP_START_DATE.getTime() - 7 * 24 * 60 * 60 * 1000); // 대표 모집 시작 일주일 전
+
+const TODAY = new Date();
+
 function RecuritHeader() {
-  const [isRecruitmentOver, setIsRecruitmentOver] = useState(false);
+  const [currentStatus, setCurrentStatus] = useState('');
   const [timeRemaining, setTimeRemaining] = useState({ days: 0, hours: 0, minutes: 0, seconds: 0 });
-  const [isInit, setIsInit] = useState(false);
-  const navigate = useNavigate();
 
-  const cardRef = useRef(null);
-  const [isVisible, setIsVisible] = useState(false);
+  const formatDate = (date: Date) => {
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      weekday: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+    };
 
-  // 모달 오픈
-  const [isModalOpen, setModalOpen] = useState(false);
+    return date
+      .toLocaleDateString('ko-KR', options)
+      .replace(/(\d{4})\s(\d{2})\s(\d{2})/, '$1.$2.$3') // Add periods between year, month, and day
+      .replace(/\s/g, '') // Remove spaces
+      .replace(/(\(\S+\))/, '$1 '); // Add space before and after the weekday
+  };
 
-  const toggleModal = () => {
-    setModalOpen((prev) => !prev);
+  const updateRemainingTime = (targetDate: Date) => {
+    const currentDate = new Date();
+    const timeDifference = targetDate.getTime() - currentDate.getTime();
+
+    if (timeDifference > 0) {
+      const days = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((timeDifference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+      const minutes = Math.floor((timeDifference % (1000 * 60 * 60)) / (1000 * 60));
+      const seconds = Math.floor((timeDifference % (1000 * 60)) / 1000);
+
+      setTimeRemaining({ days, hours, minutes, seconds });
+    }
   };
 
   useEffect(() => {
-    const targetDate = new Date('2024-01-13T00:00:00+09:00');
+    const currentDate = new Date();
 
-    const updateRemainingTime = () => {
-      const currentDate = new Date();
-      const timeDifference = targetDate - currentDate;
-
-      if (timeDifference > 0) {
-        const days = Math.floor(timeDifference / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((timeDifference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-        const minutes = Math.floor((timeDifference % (1000 * 60 * 60)) / (1000 * 60));
-        const seconds = Math.floor((timeDifference % (1000 * 60)) / 1000);
-
-        setTimeRemaining({ days, hours, minutes, seconds });
-      } else {
-        setIsRecruitmentOver(true);
-      }
-
-      setIsInit(true);
-    };
-
-    const intervalId = setInterval(updateRemainingTime, 1000);
-
-    // 컴포넌트가 언마운트될 때 clearInterval을 통해 interval 정리
-    return () => clearInterval(intervalId);
+    if (currentDate >= REP_START_ONE_WEEK_BEFORE && currentDate < REP_START_DATE) {
+      setCurrentStatus('oneWeekBeforeRepStart');
+      updateRemainingTime(REP_START_DATE);
+    } else if (currentDate >= REP_START_DATE && currentDate < REP_END_DATE) {
+      setCurrentStatus('repRecruiting');
+      updateRemainingTime(REP_END_DATE);
+    } else if (currentDate >= REP_END_DATE && currentDate < TEAM_START_DATE) {
+      setCurrentStatus('afterRepBeforeTeam');
+      updateRemainingTime(TEAM_START_DATE);
+    } else if (currentDate >= TEAM_START_DATE && currentDate < TEAM_END_DATE) {
+      setCurrentStatus('teamRecruiting');
+      updateRemainingTime(TEAM_END_DATE);
+    } else if (currentDate >= TEAM_END_DATE) {
+      setCurrentStatus('afterTeamRecruiting');
+    }
   }, []);
 
   // 버튼 클릭시
   const handleButtonClick = () => {
-    // 모집기간 지났을때 구글폼으로
-    if (isRecruitmentOver) {
-      window.open('https://forms.gle/rDKEvu58VSZqScCn9', '_blank');
+    if (currentStatus === 'afterTeamRecruiting') {
+      window.open('https://forms.gle/8qTowhqD5JptwGUx6', '_blank'); // 사전 알림 구글 폼 링크
     } else {
-      // 그 외에는 모집 페이지로
-      navigate('/apply');
+      navigate('/about'); // 모집 페이지로 이동
     }
   };
 
-  // 모집 중 컨텐츠
-  const RecruitmentContent = () => (
-    <>
-      <S.HeaderTitleText>
-        구름톤 유니브 4기 모집 중!
-        <h4>
-          {isInit ? (
-            <>
-              {timeRemaining.hours + timeRemaining.days * 24}시간 {timeRemaining.minutes}분 {timeRemaining.seconds}초
-            </>
-          ) : (
-            <>
-              <Spinner />
-            </>
-          )}
-        </h4>
-      </S.HeaderTitleText>
-      <Button className={styles.goormBtn} color="primary" size="xl" onClick={handleButtonClick}>
-        우리 학교 찾아보기
-      </Button>
-    </>
-  );
+  const renderContent = () => {
+    const textMapping: {
+      [key: string]: {
+        title: string;
+        subTitle: string;
+        button: string;
+        rightTitle: string;
+        dDayText: string;
+        rightSubtitle: string;
+      };
+    } = {
+      // 대표 모집 일주일 전
+      oneWeekBeforeRepStart: {
+        title: '곧 유니브 대표 모집 기간이예요!',
+        subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
+        button: '우리 학교 찾아보기',
+        rightTitle: '유니브 대표 모집 시작',
+        dDayText: `D-${timeRemaining.days}`,
+        rightSubtitle: formatDate(REP_START_DATE),
+      },
 
-  // 마감 후 콘텐츠
-  const RecruitmentClosedContent = () => (
-    <div className={cx('container')}>
-      <div className={cx('leftSection')}>
-        <Text className={cx('titleText')} typography="heading1" color="text-normal">
-          3기 모집이 완료되었어요!
-        </Text>
-        <Text className={cx('titleTextSmall')} typography="heading6" color="text-hint">
-          구름톤 유니브 4기로 활동하고 싶으신가요?
-        </Text>
-        <Button className={cx('goormBtn')}>4기 사전 알림 받기</Button>
-      </div>
-      <div className={cx('rightSection')}>
-        <Text typography="heading4" color="text-alternative">
-          4기 모집 시작
-        </Text>
-        <Text className={cx('dDayText')} color="text-alternative">
-          25년 1월
-        </Text>
-        <Text typography="heading6" color="text-hint">
-          Coming soon!
-        </Text>
-      </div>
-    </div>
-  );
+      // 대표 모집 기간
+      repRecruiting: {
+        title: '유니브 대표 모집 기간이예요!',
+        subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
+        button: '우리 학교 찾아보기',
+        rightTitle: '유니브 대표 모집 마감',
+        dDayText: `D-${timeRemaining.days}`,
+        rightSubtitle: formatDate(REP_END_DATE),
+      },
 
-  return (
-    <>
-      {/* <S.HeaderContainer className="container"> */}
-      {/* <S.HeaderTitleWrapper className="d-flex justify-content-center align-items-center flex-column"> */}
-      <RecruitmentClosedContent />
-      {/* </S.HeaderTitleWrapper> */}
-      {isModalOpen && <RecruitModal isModalOpen={isModalOpen} toggleModal={toggleModal} />} {/* </S.HeaderContainer> */}
-    </>
-  );
+      // 대표 모집 마감 후, 미르미 모집 시작 전
+      afterRepBeforeTeam: {
+        title: '곧 미르미 모집 기간이에요!',
+        subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
+        button: '우리 학교 찾아보기',
+        rightTitle: '유니브 팀원 모집 시작',
+        dDayText: `D-${timeRemaining.days}`,
+        rightSubtitle: '유니브 별로 일정 상이',
+      },
+
+      // 미르미 모집 중
+      teamRecruiting: {
+        title: '미르미 모집 기간이예요!',
+        subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
+        button: '우리 학교 찾아보기',
+        rightTitle: '유니브 팀원 모집 마감',
+        dDayText: `D-${timeRemaining.days}`,
+        rightSubtitle: '유니브 별로 일정 상이',
+      },
+
+      // 대표 모집 마감 이후
+      afterTeamRecruiting: {
+        title: '3기 모집이 완료되었어요!',
+        subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
+        button: '4기 사전 알림 받기',
+        rightTitle: '4기 모집 시작',
+        dDayText: '25년 1월',
+        rightSubtitle: 'Coming soon!',
+      },
+    };
+
+    const { title, subTitle, button, rightTitle, dDayText, rightSubtitle } = textMapping[currentStatus] || {};
+
+    return (
+      <div className={cx('container')}>
+        <div className={cx('leftSection')}>
+          <Text className={cx('titleText')} typography="heading1" color="text-normal">
+            {title}
+          </Text>
+          <Text className={cx('titleTextSmall')} typography="heading6" color="text-hint">
+            {subTitle}
+          </Text>
+          <Button className={cx('goormBtn')} onClick={handleButtonClick}>
+            {button}
+          </Button>
+        </div>
+        <div className={cx('rightSection')}>
+          <Text typography="heading4" color="text-alternative">
+            {rightTitle}
+          </Text>
+          <Text className={cx('dDayText')} color="text-alternative">
+            {dDayText}
+          </Text>
+          <Text typography="heading6" color="text-hint">
+            {rightSubtitle}
+          </Text>
+        </div>
+      </div>
+    );
+  };
+
+  return renderContent();
 }
 
 export default RecuritHeader;

--- a/src/components/recruit/recuritHeader/RecuritHeader.tsx
+++ b/src/components/recruit/recuritHeader/RecuritHeader.tsx
@@ -11,7 +11,7 @@ import { TYPOGRAPHY } from '@goorm-dev/vapor-components/dist/types/src/component
 const cx = classNames.bind(styles);
 
 const REP_START_DATE = new Date('2024-08-10T10:00:00');
-const REP_END_DATE = new Date('2024-08-25T10:00:00');
+const REP_END_DATE = new Date('2024-08-22T19:00:00');
 const TEAM_START_DATE = new Date('2024-08-01T10:00:00');
 const TEAM_END_DATE = new Date('2024-08-15T10:00:00');
 const REP_START_ONE_WEEK_BEFORE = new Date(REP_START_DATE.getTime() - 7 * 24 * 60 * 60 * 1000); // 대표 모집 시작 일주일 전
@@ -35,9 +35,9 @@ function RecuritHeader() {
 
     return date
       .toLocaleDateString('ko-KR', options)
-      .replace(/(\d{4})\s(\d{2})\s(\d{2})/, '$1.$2.$3') // Add periods between year, month, and day
-      .replace(/\s/g, '') // Remove spaces
-      .replace(/(\(\S+\))/, '$1 '); // Add space before and after the weekday
+      .replace(/(\d{4})\s(\d{2})\s(\d{2})/, '$1.$2.$3')
+      .replace(/\s/g, '') // 공백 제거
+      .replace(/(\(\S+\))/, '$1 ');
   };
 
   const updateRemainingTime = (targetDate: Date) => {
@@ -100,7 +100,7 @@ function RecuritHeader() {
         subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
         button: '우리 학교 찾아보기',
         rightTitle: '유니브 대표 모집 시작',
-        dDayText: `D-${timeRemaining.days}`,
+        dDayText: timeRemaining.days === 0 ? 'D-day' : `D-${timeRemaining.days}`,
         rightSubtitle: formatDate(REP_START_DATE),
       },
 
@@ -110,7 +110,7 @@ function RecuritHeader() {
         subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
         button: '우리 학교 찾아보기',
         rightTitle: '유니브 대표 모집 마감',
-        dDayText: `D-${timeRemaining.days}`,
+        dDayText: timeRemaining.days === 0 ? 'D-day' : `D-${timeRemaining.days}`,
         rightSubtitle: formatDate(REP_END_DATE),
       },
 
@@ -120,7 +120,7 @@ function RecuritHeader() {
         subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
         button: '우리 학교 찾아보기',
         rightTitle: '유니브 팀원 모집 시작',
-        dDayText: `D-${timeRemaining.days}`,
+        dDayText: timeRemaining.days === 0 ? 'D-day' : `D-${timeRemaining.days}`,
         rightSubtitle: '유니브 별로 일정 상이',
       },
 
@@ -130,7 +130,7 @@ function RecuritHeader() {
         subTitle: '우리 학교가 유니브에 소속되어있는지 궁금하신가요?',
         button: '우리 학교 찾아보기',
         rightTitle: '유니브 팀원 모집 마감',
-        dDayText: `D-${timeRemaining.days}`,
+        dDayText: timeRemaining.days === 0 ? 'D-day' : `D-${timeRemaining.days}`,
         rightSubtitle: '유니브 별로 일정 상이',
       },
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #8

## ⛅️ 작업 내용

- [x] Recruit Header Dday 분기 처리
- [x] Recruit Header Dday 시간 추가
- [x] Recruit Header D-0일시에 D-day로 변경

```
const REP_START_DATE = new Date('2024-08-10T10:00:00');
const REP_END_DATE = new Date('2024-08-22T19:00:00');
const TEAM_START_DATE = new Date('2024-08-01T10:00:00');
const TEAM_END_DATE = new Date('2024-08-15T10:00:00');
```
이런 식으로 날짜 지정해서 적어두면 반영되게 해두었고 멘트도 기간별로 수정할 수 있도록 작성했습니다

## 👀 스크린샷 / GIF / 링크
![스크린샷 2024-08-22 오후 4 01 51](https://github.com/user-attachments/assets/5fa77147-c718-49a3-a078-e8fcf884297e)
