### PR TITLE
[Feat/#85] 추가된 UX 반영

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,6 @@
 // 회원 관련 api
 
+import { GENERATION } from '../constants/common';
 import instance from './instance';
 
 // JWT 토큰 재발급
@@ -42,7 +43,7 @@ export const resetPasswordAPI = async (current_password: string, new_password: s
 
 // 유저 정보 가져오기
 export const getUserBriefAPI = async () => {
-  const response = await instance.get('/api/v1/auth/briefs');
+  const response = await instance.get(`/api/v1/auth/briefs?generation=${GENERATION}`);
 
   return response.data;
 };

--- a/src/components/hackathon/ideaForm/PositionForm.tsx
+++ b/src/components/hackathon/ideaForm/PositionForm.tsx
@@ -5,32 +5,24 @@ import { useIdeaFormStore } from '../../../store/useIdeaFormStore';
 import FormTextarea from './FormTextarea';
 import FormDropdown from './FormDropdown';
 import StackSelector from './StackSelector';
-
-type Position = 'pm' | 'pd' | 'fe' | 'be';
+import { POSITIONS } from '../../../constants/position';
 
 interface PositionFormProps {
   position: {
-    key: Position;
+    key: keyof typeof POSITIONS;
     name: string;
     index: number;
   };
   isDisabled: boolean;
 }
 
-const POSITION_NAME = {
-  pm: '기획',
-  pd: '디자인',
-  fe: '프론트엔드',
-  be: '백엔드',
-};
-
 export default function PositionForm({ position, isDisabled }: PositionFormProps) {
   const { requirements, updateRequirements } = useIdeaFormStore();
 
   // const isDisabled = position.key === idea_info.provider_role;
-  const currentValue = requirements[position.key as Position] || {
+  const currentValue = requirements[position.key as keyof typeof POSITIONS] || {
     requirement: '',
-    capacity: requirements[position.key as Position]?.capacity || 0,
+    capacity: requirements[position.key as keyof typeof POSITIONS]?.capacity || 0,
     required_tech_stacks: [],
   };
 
@@ -42,16 +34,16 @@ export default function PositionForm({ position, isDisabled }: PositionFormProps
   };
 
   const handleChange = (value: any) => {
-    updateRequirements(position.key as Position, {
+    updateRequirements(position.key as keyof typeof POSITIONS, {
       ...currentValue,
       ...value,
     });
   };
 
   return (
-    <div className={styles.positionFormContainer}>
+    <div className={isDisabled ? styles.positionFormContainerDisabled : styles.positionFormContainer}>
       <Text as="h6" typography="heading6" color="text-normal" style={{ marginBottom: 'var(--space-200)' }}>
-        {`${position.index + 1}. ${POSITION_NAME[position.key as keyof typeof POSITION_NAME]}`}
+        {`${position.index + 1}. ${POSITIONS[position.key as keyof typeof POSITIONS]}`}
       </Text>
       <FormTextarea
         label="원하는 팀원상"

--- a/src/components/hackathon/ideaForm/styles.module.scss
+++ b/src/components/hackathon/ideaForm/styles.module.scss
@@ -110,3 +110,8 @@
   gap: 0.375rem;
   flex-wrap: wrap;
 }
+
+.positionFormContainerDisabled {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/src/components/hackathon/ideaList/filter/BookmarkedFilterDropdown.tsx
+++ b/src/components/hackathon/ideaList/filter/BookmarkedFilterDropdown.tsx
@@ -1,0 +1,40 @@
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem, Text } from '@goorm-dev/vapor-components';
+import { useState } from 'react';
+import styles from './styles.module.scss';
+
+interface BookmarkedFilterDropdownProps {
+  options: { label: string; value: boolean }[];
+  selectedValue: boolean | undefined;
+  onChange: (value: boolean | undefined) => void;
+  disabled?: boolean;
+}
+
+export default function BookmarkedFilterDropdown({
+  options,
+  selectedValue,
+  onChange,
+  disabled = false,
+}: BookmarkedFilterDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = () => !disabled && setIsOpen(!isOpen);
+
+  // 현재 선택된 옵션 표시
+  const selectedOptionName = options.find((option) => option.value === selectedValue)?.label || '전체';
+
+  return (
+    <Dropdown direction="down" size="lg" isOpen={isOpen} toggle={toggle} disabled={disabled}>
+      <DropdownToggle caret color="select" className={styles.dropdown} disabled={disabled}>
+        <Text typography="body2" fontWeight="medium" className={styles.textSelect}>
+          {selectedOptionName}
+        </Text>
+      </DropdownToggle>
+      <DropdownMenu>
+        {options.map((option) => (
+          <DropdownItem key={option.label} onClick={() => onChange(option.value)}>
+            {option.label}
+          </DropdownItem>
+        ))}
+      </DropdownMenu>
+    </Dropdown>
+  );
+}

--- a/src/components/layout/navbar/CustomNavbar.tsx
+++ b/src/components/layout/navbar/CustomNavbar.tsx
@@ -1,18 +1,30 @@
-import { Button, GoormNavbar } from '@goorm-dev/gds-components';
+import { GoormNavbar } from '@goorm-dev/gds-components';
 import { ChevronRightOutlineIcon, OutOutlineIcon } from '@goorm-dev/vapor-icons';
 import { useState } from 'react';
 import { GoormBlackBI, GoormWhiteBI } from '../../../assets';
 import { useIsAbout } from '../../../hooks/useIsAbout';
 import styles from './customNavbar.module.scss';
-import { Nav, NavItem, NavLink } from '@goorm-dev/vapor-components';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+  Nav,
+  NavItem,
+  NavLink,
+} from '@goorm-dev/vapor-components';
+import { useNavigate } from 'react-router-dom';
+import useAuthStore from '../../../store/useAuthStore';
 
 function CustomNavbar() {
   const [isOpened, setIsOpened] = useState(false);
+  const [isHackathonOpened, setIsHackathonOpened] = useState(false);
   const isAbout = useIsAbout();
+  const navigate = useNavigate();
 
-  // TODO: 로그인 여부 확인 로직 추가
-  const isLoggedIn = false;
-
+  const isLoggedIn = useAuthStore((state) => state.role !== 'GUEST');
+  const profileImg = useAuthStore((state) => state.profile_img);
   const NAV_ITEMS = [
     {
       title: 'Project',
@@ -21,18 +33,6 @@ function CustomNavbar() {
     {
       title: 'Recruit',
       to: '/recruit',
-    },
-    // {
-    //   title: 'Hackathon',
-    //   to: '/hackathon',
-    // },
-    {
-      title: (
-        <>
-          UNIV-LOG <OutOutlineIcon className="mx-1" />
-        </>
-      ),
-      to: 'https://9oormthonuniv.tistory.com/',
     },
   ];
 
@@ -55,7 +55,35 @@ function CustomNavbar() {
               </NavLink>
             </NavItem>
           ))}
+
+          {isLoggedIn && (
+            <Dropdown
+              direction="down"
+              nav={true}
+              size="lg"
+              isOpen={isHackathonOpened}
+              toggle={() => setIsHackathonOpened((prev) => !prev)}
+              inNavbar={true}>
+              <DropdownToggle caret color="select" className={styles.dropdownToggle}>
+                Hackathon
+              </DropdownToggle>
+              <DropdownMenu right>
+                <DropdownItem onClick={() => navigate('/hackathon')}>아이디어</DropdownItem>
+                <DropdownItem onClick={() => alert('준비중인 기능입니다.')}>나의 팀</DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          )}
+          <NavItem>
+            <NavLink
+              className={isAbout ? styles.whiteFont : ''}
+              href="https://9oormthonuniv.tistory.com/"
+              target="_blank"
+              rel="noopener noreferrer">
+              UNIV-LOG <OutOutlineIcon className="mx-1" />
+            </NavLink>
+          </NavItem>
         </Nav>
+
         <Nav navbar className={styles.navbar}>
           <NavLink
             className={isAbout ? styles.whiteFont : ''}
@@ -65,7 +93,9 @@ function CustomNavbar() {
           </NavLink>
 
           {isLoggedIn ? (
-            <NavLink className={styles.grayCircle} href="/my-page"></NavLink>
+            <NavLink className={styles.grayCircle} href="/my-page">
+              {profileImg && <img src={profileImg} alt="profile" className={styles.profileImg} />}
+            </NavLink>
           ) : (
             <>
               {/* <Button className={styles.loginButton} size="lg" href="/login"> */}

--- a/src/components/layout/navbar/customNavbar.module.scss
+++ b/src/components/layout/navbar/customNavbar.module.scss
@@ -18,10 +18,10 @@
 
 .loginText {
   color: var(--gray-900);
-  @include container-xs {
+  @include container-md {
     display: inline-flex;
   }
-  @include container-md {
+  @include container-lg {
     display: none;
   }
 }
@@ -29,6 +29,7 @@
 .collapse {
   width: 100%;
   display: flex;
+  overflow: visible !important;
   @include container-xs {
     flex-direction: column;
     align-items: start;
@@ -80,4 +81,34 @@
   background-color: var(--gray-200);
   border-radius: 1.25rem;
   margin-left: -0.1rem;
+
+  &:hover {
+    background-color: var(--gray-200) !important;
+  }
+
+  &:focus {
+    background-color: var(--gray-200) !important;
+  }
+}
+
+.dropdownToggle {
+  border: none !important;
+  padding: 0.5625rem 0.5rem !important;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  color: var(--text-alternative);
+  height: var(--dimension-400) !important;
+  font-weight: 500;
+
+  &:hover {
+    background: var(--gray-400-transparent-16);
+    outline: 0;
+  }
+}
+
+.profileImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -18,3 +18,6 @@ export const allProjects = [...DanpoongProject2023Data, ...BeotkkotProject2024Da
 );
 
 export const PROJECTS = [allProjects, DanpoongProject2023Data, BeotkkotProject2024Data, DanpungProject2024Data];
+
+// 기수 (추후 변경 필요)
+export const GENERATION = 4;

--- a/src/pages/hackathon/IdeaList/IdeaList.tsx
+++ b/src/pages/hackathon/IdeaList/IdeaList.tsx
@@ -10,7 +10,7 @@ import ActiveFilterDropdown from '../../../components/hackathon/ideaList/filter/
 import SubjectFilterDropdown from '../../../components/hackathon/ideaList/filter/SubjectFilterDropdown';
 import { useNavigate } from 'react-router-dom';
 import BookmarkedFilterDropdown from '../../../components/hackathon/ideaList/filter/BookmarkedFilterDropdown';
-import useAuthStore from '../../../store/useAuthStore';
+import { getUserBriefAPI } from '../../../api/auth';
 
 export default function IdeaList() {
   const navigate = useNavigate();
@@ -25,14 +25,13 @@ export default function IdeaList() {
   });
   const { ideas, page_info } = ideaList;
   const [loading, setLoading] = useState(false);
-  const { is_provider } = useAuthStore();
 
   // 필터링
   const [selectedTopic, setSelectedTopic] = useState<number>(0);
   const [selectedStatus, setSelectedStatus] = useState<boolean | undefined>(undefined);
   const [selectedBookmark, setSelectedBookmark] = useState<boolean | undefined>(undefined);
   const [currentPage, setCurrentPage] = useState(1);
-
+  const [isProvider, setIsProvider] = useState<boolean | null>(null);
   // 상태 옵션
   const statusOptions = [
     { label: '전체', value: undefined },
@@ -45,6 +44,21 @@ export default function IdeaList() {
     { label: '전체', value: false },
     { label: '찜한 아이디어', value: true },
   ];
+
+  // 아이디어 제공자인지 확인
+  useEffect(() => {
+    const loadIsProvider = async () => {
+      try {
+        const response = await getUserBriefAPI();
+        const { is_provider } = response.data;
+        setIsProvider(is_provider);
+      } catch (error) {
+        console.error('Error fetching is_provider:', error);
+      }
+    };
+
+    loadIsProvider();
+  }, []);
 
   // 주제 가져오는 api
   useEffect(() => {
@@ -127,7 +141,7 @@ export default function IdeaList() {
 
   //아이디어 등록 버튼 누를 때 is_provider가 true이면 alert띄우기
   const handleCreateIdea = () => {
-    if (is_provider) {
+    if (isProvider) {
       toast(message, {
         type: 'danger',
       });

--- a/src/pages/hackathon/IdeaList/IdeaList.tsx
+++ b/src/pages/hackathon/IdeaList/IdeaList.tsx
@@ -8,6 +8,8 @@ import { fetchIdeas, fetchIdeaSubjects, addIdeaBookmark } from '../../../api/ide
 import ActiveFilterDropdown from '../../../components/hackathon/ideaList/filter/ActiveFilterDropdown';
 import SubjectFilterDropdown from '../../../components/hackathon/ideaList/filter/SubjectFilterDropdown';
 import { useNavigate } from 'react-router-dom';
+import BookmarkedFilterDropdown from '../../../components/hackathon/ideaList/filter/BookmarkedFilterDropdown';
+
 export default function IdeaList() {
   const navigate = useNavigate();
   // 주제 가져오기
@@ -25,12 +27,20 @@ export default function IdeaList() {
   // 필터링
   const [selectedTopic, setSelectedTopic] = useState<number>(0);
   const [selectedStatus, setSelectedStatus] = useState<boolean | undefined>(undefined);
+  const [selectedBookmark, setSelectedBookmark] = useState<boolean | undefined>(undefined);
   const [currentPage, setCurrentPage] = useState(1);
 
+  // 상태 옵션
   const statusOptions = [
     { label: '전체', value: undefined },
     { label: '모집 중', value: true },
     { label: '모집 완료', value: false },
+  ];
+
+  // 북마크 옵션
+  const bookmarkOptions = [
+    { label: '전체', value: false },
+    { label: '찜한 아이디어', value: true },
   ];
 
   // 주제 가져오는 api
@@ -59,8 +69,8 @@ export default function IdeaList() {
         const subjectId = selectedTopic === 0 ? undefined : selectedTopic;
         const isActive = selectedStatus === true ? true : selectedStatus === false ? false : undefined;
 
-        console.log(subjectId, isActive);
-        const response = await fetchIdeas(currentPage, projectsPerPage, 4, subjectId, isActive);
+        const isBookmarked = selectedBookmark === true ? true : selectedBookmark === false ? false : undefined;
+        const response = await fetchIdeas(currentPage, projectsPerPage, 4, subjectId, isActive, isBookmarked);
         setIdeaList(response.data);
       } catch (error) {
         console.error('Error fetching ideas:', error);
@@ -70,7 +80,7 @@ export default function IdeaList() {
     };
 
     loadIdeas();
-  }, [selectedTopic, selectedStatus, currentPage]);
+  }, [selectedTopic, selectedStatus, currentPage, selectedBookmark]);
 
   // 팀빌딩 기간인지
   const isTeamBuilding = true;
@@ -132,6 +142,12 @@ export default function IdeaList() {
                 options={statusOptions}
                 selectedValue={selectedStatus}
                 onChange={(value) => setSelectedStatus(value)}
+                disabled={!isTeamBuilding}
+              />
+              <BookmarkedFilterDropdown
+                options={bookmarkOptions}
+                selectedValue={selectedBookmark}
+                onChange={(value) => setSelectedBookmark(value)}
                 disabled={!isTeamBuilding}
               />
             </div>

--- a/src/pages/hackathon/IdeaList/IdeaList.tsx
+++ b/src/pages/hackathon/IdeaList/IdeaList.tsx
@@ -1,4 +1,5 @@
-import { BasicPagination, Button, Spinner } from '@goorm-dev/vapor-components';
+import { BasicPagination, Button, Slide, Spinner, toast, ToastContainer } from '@goorm-dev/vapor-components';
+import 'react-toastify/dist/ReactToastify.min.css';
 import NoAccess from '../../../components/hackathon/ideaList/noAccess/NoAccess';
 import styles from './styles.module.scss';
 import { EditIcon } from '@goorm-dev/gds-icons';
@@ -9,6 +10,7 @@ import ActiveFilterDropdown from '../../../components/hackathon/ideaList/filter/
 import SubjectFilterDropdown from '../../../components/hackathon/ideaList/filter/SubjectFilterDropdown';
 import { useNavigate } from 'react-router-dom';
 import BookmarkedFilterDropdown from '../../../components/hackathon/ideaList/filter/BookmarkedFilterDropdown';
+import useAuthStore from '../../../store/useAuthStore';
 
 export default function IdeaList() {
   const navigate = useNavigate();
@@ -23,6 +25,7 @@ export default function IdeaList() {
   });
   const { ideas, page_info } = ideaList;
   const [loading, setLoading] = useState(false);
+  const { is_provider } = useAuthStore();
 
   // 필터링
   const [selectedTopic, setSelectedTopic] = useState<number>(0);
@@ -119,6 +122,20 @@ export default function IdeaList() {
     }
   };
 
+  // 예외처리
+  const message = '이미 제출된 아이디어가 있어 등록이 불가합니다.';
+
+  //아이디어 등록 버튼 누를 때 is_provider가 true이면 alert띄우기
+  const handleCreateIdea = () => {
+    if (is_provider) {
+      toast(message, {
+        type: 'danger',
+      });
+    } else {
+      navigate('/hackathon/create/step1');
+    }
+  };
+
   return (
     <div className={styles.mainContainer}>
       {/* 추후 이미지 */}
@@ -151,7 +168,7 @@ export default function IdeaList() {
                 disabled={!isTeamBuilding}
               />
             </div>
-            <Button icon={EditIcon} active={false} size="lg" href="/hackathon/create/step1" className={styles.noneBtn}>
+            <Button icon={EditIcon} active={false} size="lg" onClick={handleCreateIdea} className={styles.noneBtn}>
               아이디어 등록
             </Button>
           </div>
@@ -184,6 +201,7 @@ export default function IdeaList() {
           )}
         </div>
       )}
+      <ToastContainer autoClose={3000} transition={Slide} closeButton={false} newestOnTop hideProgressBar />
     </div>
   );
 }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -4,7 +4,6 @@ import { getUserBriefAPI, loginAPI, logoutAPI } from '../api/auth';
 interface AuthStore {
   role: string;
   profile_img: string | null;
-  is_provider: boolean | null;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   resetToGuest: () => void;
@@ -17,7 +16,6 @@ if (!localStorage.getItem('role')) {
 const useAuthStore = create<AuthStore>((set) => ({
   role: localStorage.getItem('role') || 'GUEST',
   profile_img: localStorage.getItem('profile_img') || null,
-  is_provider: localStorage.getItem('is_provider') ? JSON.parse(localStorage.getItem('is_provider')!) : null,
 
   login: async (serial_id: string, password: string) => {
     try {
@@ -25,7 +23,7 @@ const useAuthStore = create<AuthStore>((set) => ({
 
       // 로그인 성공 후 유저 role 가져오기
       const response = await getUserBriefAPI();
-      const { role, profile_img, is_provider } = response.data;
+      const { role, profile_img } = response.data;
 
       localStorage.setItem('role', role);
       if (profile_img) {
@@ -33,12 +31,10 @@ const useAuthStore = create<AuthStore>((set) => ({
       } else {
         localStorage.removeItem('profile_img');
       }
-      localStorage.setItem('is_provider', JSON.stringify(is_provider));
 
       set({
         role,
         profile_img: profile_img || null,
-        is_provider,
       });
     } catch (error) {
       console.error('Login failed', error);
@@ -54,15 +50,13 @@ const useAuthStore = create<AuthStore>((set) => ({
     }
     localStorage.setItem('role', 'GUEST');
     localStorage.removeItem('profile_img');
-    localStorage.removeItem('is_provider');
-    set({ role: 'GUEST', profile_img: null, is_provider: null });
+    set({ role: 'GUEST', profile_img: null });
   },
 
   resetToGuest: () => {
     localStorage.setItem('role', 'GUEST');
     localStorage.removeItem('profile_img');
-    localStorage.removeItem('is_provider');
-    set({ role: 'GUEST', profile_img: null, is_provider: null });
+    set({ role: 'GUEST', profile_img: null });
   },
 }));
 

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -3,6 +3,8 @@ import { getUserBriefAPI, loginAPI, logoutAPI } from '../api/auth';
 
 interface AuthStore {
   role: string;
+  profile_img: string | null;
+  is_provider: boolean | null;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   resetToGuest: () => void;
@@ -14,17 +16,30 @@ if (!localStorage.getItem('role')) {
 
 const useAuthStore = create<AuthStore>((set) => ({
   role: localStorage.getItem('role') || 'GUEST',
+  profile_img: localStorage.getItem('profile_img') || null,
+  is_provider: localStorage.getItem('is_provider') ? JSON.parse(localStorage.getItem('is_provider')!) : null,
 
   login: async (serial_id: string, password: string) => {
     try {
       await loginAPI(serial_id, password);
 
-      // 로그인 성공하고, 유저 role 가져오는 api
+      // 로그인 성공 후 유저 role 가져오기
       const response = await getUserBriefAPI();
-      const userRole = response.data.role;
+      const { role, profile_img, is_provider } = response.data;
 
-      localStorage.setItem('role', userRole);
-      set({ role: userRole });
+      localStorage.setItem('role', role);
+      if (profile_img) {
+        localStorage.setItem('profile_img', profile_img);
+      } else {
+        localStorage.removeItem('profile_img');
+      }
+      localStorage.setItem('is_provider', JSON.stringify(is_provider));
+
+      set({
+        role,
+        profile_img: profile_img || null,
+        is_provider,
+      });
     } catch (error) {
       console.error('Login failed', error);
       throw error;
@@ -38,12 +53,16 @@ const useAuthStore = create<AuthStore>((set) => ({
       console.error('Logout error', error);
     }
     localStorage.setItem('role', 'GUEST');
-    set({ role: 'GUEST' });
+    localStorage.removeItem('profile_img');
+    localStorage.removeItem('is_provider');
+    set({ role: 'GUEST', profile_img: null, is_provider: null });
   },
 
   resetToGuest: () => {
     localStorage.setItem('role', 'GUEST');
-    set({ role: 'GUEST' });
+    localStorage.removeItem('profile_img');
+    localStorage.removeItem('is_provider');
+    set({ role: 'GUEST', profile_img: null, is_provider: null });
   },
 }));
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #85 

## ⛅️ 작업 내용

- [x] 아이디어 등록 부분에서 기/디 선택 시 게시물이 disabled되는 UX 추가
- [x] 이미 아이디어를 등록했을 시, 두 번 등록못하도록 alert메시지 추가
- [x] 찜한 아이디어 dropdown 추가
- [x] 해커톤 네브바에 아이디어 및 해커톤 추가
- [x] 인증 정보 전역 상태 관리 추가
- [x] 네브바에 로그인 상태 처리

## ✅ PR Point

<!-- 무슨 이유로 어떻게 코드를 변경했는지 -->
<!-- 어떤 위험이나 우려가 발견되었는지(팀원이 알아야 할 것) -->
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 -->
- api 매번 호출이 아닌 전역 상태 관리로 로그인을 구현하였습니다. 예외처리 테스트 필요합니다.

