### PR TITLE
[feat/#104] provider 입장의 기간 별 지원현황 보기

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -29,3 +29,15 @@ export const getIdeaApplyStatus = async (generation: number, phase: number) => {
   const response = await instance.get(`/api/v1/users/teams/applies/overviews?generation=${generation}&phase=${phase}`);
   return response.data;
 };
+
+// 지원 결정 (수락)
+export const acceptApply = async (applyId: number) => {
+  const response = await instance.post(`/api/v1/users/applies/${applyId}/accept`);
+  return response.data;
+};
+
+// 지원 결정 (거절)
+export const rejectApply = async (applyId: number) => {
+  const response = await instance.post(`/api/v1/users/applies/${applyId}/reject`);
+  return response.data;
+};

--- a/src/components/hackathon/teamBuilding/TeamBuildingPhaseSelector.tsx
+++ b/src/components/hackathon/teamBuilding/TeamBuildingPhaseSelector.tsx
@@ -1,0 +1,36 @@
+import { ButtonToggleGroup } from '@goorm-dev/vapor-components';
+import usePeriodStore from '../../../store/usePeriodStore';
+
+interface TeamBuildingPhaseSelectorProps {
+  onPhaseChange: (index: number) => void;
+  activeIndex: number;
+}
+
+export default function TeamBuildingPhaseSelector({ onPhaseChange, activeIndex }: TeamBuildingPhaseSelectorProps) {
+  // 기간 정보 불러오기
+  const { current_period, phase1_period, phase2_period, phase3_period } = usePeriodStore();
+
+  // 각 단계 그룹화 (기간 포함)
+  const phases = [
+    { label: '1차', periodText: phase1_period, keys: ['PHASE1_TEAM_BUILDING', 'PHASE1_CONFIRMATION'] },
+    { label: '2차', periodText: phase2_period, keys: ['PHASE2_TEAM_BUILDING', 'PHASE2_CONFIRMATION'] },
+    { label: '3차', periodText: phase3_period, keys: ['PHASE3_TEAM_BUILDING', 'PHASE3_CONFIRMATION'] },
+  ];
+
+  // 현재 진행 중인 단계 찾기
+  const currentPhaseIndex = phases.findIndex((phase) => phase.keys.includes(current_period));
+
+  return (
+    <ButtonToggleGroup size="lg" activeIndex={activeIndex} onToggle={onPhaseChange}>
+      {phases.map((phase, index) => {
+        const isUpcoming = index > currentPhaseIndex;
+
+        return (
+          <ButtonToggleGroup.ButtonToggleItem key={phase.label} disabled={isUpcoming}>
+            {isUpcoming ? `${phase.label} 공개 예정` : `${phase.label} (${phase.periodText || '기간 미정'})`}
+          </ButtonToggleGroup.ButtonToggleItem>
+        );
+      })}
+    </ButtonToggleGroup>
+  );
+}

--- a/src/components/hackathon/teamBuilding/applyStatusTable/ApplicantRow.tsx
+++ b/src/components/hackathon/teamBuilding/applyStatusTable/ApplicantRow.tsx
@@ -3,22 +3,50 @@ import { Button, Text } from '@goorm-dev/vapor-components';
 import { OutOutlineIcon } from '@goorm-dev/vapor-icons';
 import ApplyReasonModal from './ApplyReasonModal';
 import styles from './styles.module.scss';
+import ApplyDecisionModal from './ApplyDecisionModal';
+import { useNavigate } from 'react-router-dom';
+import usePeriodStore from '../../../../store/usePeriodStore';
 
+interface User {
+  id: number;
+  name: string;
+  univ: string;
+}
+
+// 지원 신청 정보
 interface Applicant {
   id: number;
-  preference: string;
-  name: string;
-  part: string;
-  university: string;
-  reason: string;
+  preference: number; // 지망 순위
+  motivation: string; // 지원 동기
+  role: 'PM' | 'PD' | 'BE' | 'FE'; // 역할
+  status: 'WAITING' | 'ACCEPTED' | 'REJECTED' | 'CONFIRMED' | 'ACCEPTED_NOT_JOINED'; // 현재 상태
+  user: User; // 지원자의 유저 정보 포함
 }
 
-interface ApplicantRowProps {
-  applicant: Applicant;
-}
+const roleMap: Record<Applicant['role'], string> = {
+  PM: '기획',
+  PD: '디자인',
+  BE: '백엔드',
+  FE: '프론트엔드',
+};
 
-export default function ApplicantRow({ applicant }: ApplicantRowProps) {
-  const [isOpen, setIsOpen] = useState(false);
+const statusMap = {
+  ACCEPTED: { text: '수락 완료', color: 'text-success' },
+  REJECTED: { text: '거절 완료', color: 'text-danger' },
+  CONFIRMED: { text: '확정', color: 'text-success' },
+  ACCEPTED_NOT_JOINED: { text: '도난 당함', color: 'text-hint' },
+} as const;
+
+export default function ApplicantRow({ applicant }: { applicant: Applicant }) {
+  const [isMotivationOpen, setIsMotivationOpen] = useState(false);
+  const [isAcceptOpen, setIsAcceptOpen] = useState(false);
+  const [isRejectOpen, setIsRejectOpen] = useState(false);
+  const navigate = useNavigate();
+  const handleNameClick = () => {
+    navigate(`/users/${applicant.user.id}`);
+  };
+
+  const { isTeamBuildingPeriod } = usePeriodStore();
 
   return (
     <>
@@ -27,31 +55,99 @@ export default function ApplicantRow({ applicant }: ApplicantRowProps) {
           <Text typography="body3">{applicant.preference}</Text>
         </td>
         <td>
-          <Button size="sm" color="secondary" onClick={() => setIsOpen(true)}>
+          <Button size="sm" color="secondary" onClick={() => setIsMotivationOpen(true)}>
             지원 사유 보기
           </Button>
         </td>
-        <td className={styles.nameContainer}>
-          <Text typography="body3">{applicant.name}</Text>
+        <td className={styles.nameContainer} onClick={handleNameClick}>
+          <Text typography="body3">{applicant.user.name}</Text>
           <OutOutlineIcon />
         </td>
         <td>
-          <Text typography="body3">{applicant.part}</Text>
+          <Text typography="body3">{roleMap[applicant.role as keyof typeof roleMap]}</Text>
         </td>
         <td>
-          <Text typography="body3">{applicant.university}</Text>
+          <Text typography="body3">{applicant.user.univ}</Text>
         </td>
         <td className={styles.actionButtons}>
-          <Button size="sm" color="danger">
-            거절
-          </Button>
-          <Button size="sm" color="success">
-            수락
-          </Button>
+          {/* 대기 시 / 팀 빌딩 기간이면 수락 거절 불가 */}
+          {applicant.status === 'WAITING' && (
+            <>
+              <Button
+                size="sm"
+                color="secondary"
+                onClick={() => setIsAcceptOpen(true)}
+                disabled={isTeamBuildingPeriod()}>
+                수락
+              </Button>
+              <Button
+                size="sm"
+                color="secondary"
+                onClick={() => setIsRejectOpen(true)}
+                disabled={isTeamBuildingPeriod()}>
+                거절
+              </Button>
+            </>
+          )}
+          {/* 수락 시 */}
+          {applicant.status === 'ACCEPTED' && (
+            <Text typography="subtitle1" color={statusMap[applicant.status].color}>
+              {statusMap[applicant.status].text}
+            </Text>
+          )}
+          {/* 거절 시 */}
+          {applicant.status === 'REJECTED' && (
+            <Text typography="subtitle1" color={statusMap[applicant.status].color}>
+              {statusMap[applicant.status].text}
+            </Text>
+          )}
+          {/* 확정 시 */}
+          {applicant.status === 'CONFIRMED' && (
+            <Text typography="subtitle1" color={statusMap[applicant.status].color}>
+              {statusMap[applicant.status].text}
+            </Text>
+          )}
+          {/* 도난 당함 시 */}
+          {applicant.status === 'ACCEPTED_NOT_JOINED' && (
+            <Text typography="subtitle1" color={statusMap[applicant.status].color}>
+              {statusMap[applicant.status].text}
+            </Text>
+          )}
         </td>
       </tr>
 
-      {isOpen && <ApplyReasonModal isOpen={isOpen} toggle={() => setIsOpen(false)} {...applicant} />}
+      {/* 모달들 */}
+      {isMotivationOpen && (
+        <ApplyReasonModal
+          isOpen={isMotivationOpen}
+          toggle={() => setIsMotivationOpen(false)}
+          applyInfo={{
+            id: applicant.id,
+            motivation: applicant.motivation,
+            name: applicant.user.name,
+            role: applicant.role,
+            univ: applicant.user.univ,
+          }}
+        />
+      )}
+      {isAcceptOpen && (
+        <ApplyDecisionModal
+          id={applicant.id}
+          isOpen={isAcceptOpen}
+          toggle={() => setIsAcceptOpen(false)}
+          name={applicant.user.name}
+          decision="accept"
+        />
+      )}
+      {isRejectOpen && (
+        <ApplyDecisionModal
+          id={applicant.id}
+          isOpen={isRejectOpen}
+          toggle={() => setIsRejectOpen(false)}
+          name={applicant.user.name}
+          decision="reject"
+        />
+      )}
     </>
   );
 }

--- a/src/components/hackathon/teamBuilding/applyStatusTable/ApplyDecisionModal.tsx
+++ b/src/components/hackathon/teamBuilding/applyStatusTable/ApplyDecisionModal.tsx
@@ -1,0 +1,53 @@
+import { Modal, ModalBody, Text, Button, ModalFooter } from '@goorm-dev/vapor-components';
+import styles from './styles.module.scss';
+import { WarningIcon, CheckCircleIcon } from '@goorm-dev/vapor-icons';
+import { acceptApply } from '../../../../api/users';
+import { rejectApply } from '../../../../api/users';
+
+interface ApplyDecisionModalProps {
+  id: number;
+  isOpen: boolean;
+  toggle: () => void;
+  name: string;
+  decision: 'accept' | 'reject';
+}
+
+export default function ApplyDecisionModal({ id, isOpen, toggle, name, decision }: ApplyDecisionModalProps) {
+  const handleDecision = async (decision: 'accept' | 'reject') => {
+    if (decision === 'accept') {
+      await acceptApply(id);
+    } else {
+      await rejectApply(id);
+    }
+  };
+
+  return (
+    <Modal type="center" isOpen={isOpen} toggle={toggle}>
+      <ModalBody>
+        <div className={styles.modalBody}>
+          {decision === 'accept' ? (
+            <CheckCircleIcon className={styles.checkIcon} />
+          ) : (
+            <WarningIcon className={styles.warningIcon} />
+          )}
+          <div className={styles.modalText}>
+            <Text as="h5" typography="heading5" color="text-normal">
+              {name}님의 지원을 {decision === 'accept' ? '수락' : '거절'}하시겠어요?
+            </Text>
+            <Text as="p" typography="body2" color="text-normal">
+              한 번 결정하면 다시 되돌리지 못해요.
+            </Text>
+          </div>
+        </div>
+      </ModalBody>
+      <ModalFooter className={styles.modalFooter}>
+        <Button size="lg" color="secondary" onClick={toggle}>
+          취소
+        </Button>
+        <Button size="lg" color={decision === 'accept' ? 'success' : 'danger'} onClick={() => handleDecision(decision)}>
+          {decision === 'accept' ? '수락' : '거절'}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/components/hackathon/teamBuilding/applyStatusTable/ApplyReasonModal.tsx
+++ b/src/components/hackathon/teamBuilding/applyStatusTable/ApplyReasonModal.tsx
@@ -1,38 +1,33 @@
 import { Modal, ModalBody, ModalHeader, Text } from '@goorm-dev/vapor-components';
 import styles from './styles.module.scss';
 
-interface ApplyReasonModalProps {
+interface ApplyReason {
   id: number;
-  preference: string;
-  reason: string;
+  motivation: string;
   name: string;
-  part: string;
-  university: string;
+  role: string;
+  univ: string;
+}
+
+interface ApplyInfoProps {
+  applyInfo: ApplyReason;
   toggle: () => void;
   isOpen: boolean;
 }
 
-export default function ApplyReasonModal({
-  preference,
-  reason,
-  name,
-  part,
-  university,
-  toggle,
-  isOpen,
-}: ApplyReasonModalProps) {
+export default function ApplyReasonModal({ applyInfo, toggle, isOpen }: ApplyInfoProps) {
   return (
     <Modal type="center" isOpen={isOpen} toggle={toggle}>
       <ModalHeader toggle={toggle} />
       <ModalBody className={styles.modalBody}>
         <Text as="h5" typography="heading5">
-          {preference}
+          지원 사유
         </Text>
         <Text as="p" typography="body2">
-          {reason}
+          {applyInfo.motivation}
         </Text>
         <Text as="span" typography="body3" color="text-alternative">
-          {name} / {part} / {university}
+          {applyInfo.name} / {applyInfo.role} / {applyInfo.univ}
         </Text>
       </ModalBody>
     </Modal>

--- a/src/components/hackathon/teamBuilding/applyStatusTable/ApplyStatusTable.tsx
+++ b/src/components/hackathon/teamBuilding/applyStatusTable/ApplyStatusTable.tsx
@@ -2,51 +2,29 @@ import { Text } from '@goorm-dev/vapor-components';
 import ApplicantRow from './ApplicantRow';
 import styles from './styles.module.scss';
 
-interface Applicant {
+// 지원자 개별 정보
+interface User {
   id: number;
-  preference: string;
   name: string;
-  part: string;
-  university: string;
-  reason: string;
+  univ: string;
 }
 
-const applicants: Applicant[] = [
-  {
-    id: 1,
-    preference: '1지망',
-    name: '김구름',
-    part: '디자인',
-    university: '구름대학교',
-    reason: '사유는 이러이러해요.',
-  },
-  {
-    id: 2,
-    preference: '1지망',
-    name: '김구름',
-    part: '디자인',
-    university: '구름대학교',
-    reason: '사유는 이러이러해요.',
-  },
-  {
-    id: 3,
-    preference: '2지망',
-    name: '김구름',
-    part: '프론트엔드',
-    university: '구름대학교',
-    reason: '프론트엔드가 되고 싶어요!',
-  },
-  {
-    id: 4,
-    preference: '2지망',
-    name: '김구름',
-    part: '백엔드',
-    university: '구름대학교',
-    reason: '서버 개발에 관심이 많아요!',
-  },
-];
+// 지원 신청 정보
+interface Applicant {
+  id: number;
+  preference: number; // 지망 순위
+  motivation: string; // 지원 동기
+  role: 'PM' | 'PD' | 'BE' | 'FE'; // 역할
+  status: 'WAITING' | 'ACCEPTED' | 'REJECTED' | 'CONFIRMED' | 'ACCEPTED_NOT_JOINED'; // 현재 상태
+  user: User; // 지원자의 유저 정보 포함
+}
 
-export default function ApplyStatusTable() {
+// 전체 지원자 데이터
+interface ApplicantData {
+  applies: Applicant[]; // 지원자 목록
+}
+
+export default function ApplyStatusTable({ applicants }: { applicants: ApplicantData }) {
   return (
     <div className={styles.tableContainer}>
       <table className={styles.table}>
@@ -81,7 +59,7 @@ export default function ApplyStatusTable() {
           </tr>
         </thead>
         <tbody>
-          {applicants.map((applicant) => (
+          {applicants?.applies?.map((applicant) => (
             <ApplicantRow key={applicant.id} applicant={applicant} />
           ))}
         </tbody>

--- a/src/components/hackathon/teamBuilding/applyStatusTable/styles.module.scss
+++ b/src/components/hackathon/teamBuilding/applyStatusTable/styles.module.scss
@@ -45,3 +45,46 @@ th {
   gap: var(--space-100);
   align-items: flex-start;
 }
+
+.modalBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-100);
+  align-items: center;
+
+  svg {
+    width: 6.25rem;
+    height: 6.25rem;
+  }
+}
+
+.modalText {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-050);
+  align-items: center;
+}
+
+.checkIcon {
+  color: var(--success);
+  fill: var(--success);
+}
+
+.warningIcon {
+  color: var(--danger);
+  fill: var(--danger);
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  width: 100%;
+  border-top: 1px solid var(--border-color);
+  padding: 1rem 1.5rem;
+
+  button {
+    flex-grow: 0;
+    margin: 0;
+  }
+}

--- a/src/components/myPage/MyPageHeader.tsx
+++ b/src/components/myPage/MyPageHeader.tsx
@@ -10,7 +10,7 @@ import {
 } from '@goorm-dev/vapor-icons';
 import styles from './styles.module.scss';
 import { LinkType } from '../../constants/linkType';
-
+import { useNavigate } from 'react-router-dom';
 export interface Link {
   type: LinkType;
   url: string;
@@ -42,6 +42,7 @@ const getLinkIcon = (type: LinkType) => {
 };
 
 export const MyPageHeader = ({ name, email, univ, img_url, links, is_me }: MyPageHeaderProps) => {
+  const navigate = useNavigate();
   return (
     <div className={styles.header}>
       <div className={styles.headerLeft}>
@@ -69,7 +70,7 @@ export const MyPageHeader = ({ name, email, univ, img_url, links, is_me }: MyPag
             </div>
           </div>
           {is_me && (
-            <Button color="secondary" size="sm">
+            <Button color="secondary" size="sm" onClick={() => navigate('/my-page/edit')}>
               내 정보 수정
             </Button>
           )}

--- a/src/pages/hackathon/teamBuilding/applicant/ApplicantPage.tsx
+++ b/src/pages/hackathon/teamBuilding/applicant/ApplicantPage.tsx
@@ -1,65 +1,41 @@
 import { useEffect, useState } from 'react';
 import styles from './styles.module.scss';
-import { ButtonToggleGroup, Text } from '@goorm-dev/vapor-components';
+import { Text } from '@goorm-dev/vapor-components';
 import IdeaApplyListItem from '../../../../components/hackathon/teamBuilding/IdeaApplyListItem';
 import { getMyApplySummary } from '../../../../api/users';
 import usePeriodStore from '../../../../store/usePeriodStore';
+import TeamBuildingPhaseSelector from '../../../../components/hackathon/teamBuilding/TeamBuildingPhaseSelector';
 
 export default function ApplicantPage() {
   const [buttonIndex, setButtonIndex] = useState(0);
   const [applySummary, setApplySummary] = useState<any>(null);
 
-  // 현재 팀 빌딩 기간 조회
-  const { current_period, phase1_period, phase2_period, phase3_period, fetchPeriodData } = usePeriodStore();
+  // 현재 팀빌딩 기간 조회
+  const { fetchPeriodData } = usePeriodStore();
 
   useEffect(() => {
     fetchPeriodData();
   }, []);
 
-  // 각 단계 그룹화 (기간 포함)
-  const phases = [
-    { label: '1차', periodText: phase1_period, keys: ['PHASE1_TEAM_BUILDING', 'PHASE1_CONFIRMATION'] },
-    { label: '2차', periodText: phase2_period, keys: ['PHASE2_TEAM_BUILDING', 'PHASE2_CONFIRMATION'] },
-    { label: '3차', periodText: phase3_period, keys: ['PHASE3_TEAM_BUILDING', 'PHASE3_CONFIRMATION'] },
-  ];
-
-  const currentPhaseIndex = phases.findIndex((phase) => phase.keys.includes(current_period));
-
   // 지원 내역 조회
   useEffect(() => {
-    if (currentPhaseIndex >= 0) {
-      const fetchApplySummary = async () => {
-        try {
-          const response = await getMyApplySummary(4, buttonIndex + 1);
-          setApplySummary(response.data);
-        } catch (error) {
-          console.error('Error fetching apply summary:', error);
-        }
-      };
-      fetchApplySummary();
-    }
-  }, [buttonIndex, currentPhaseIndex]);
+    const fetchApplySummary = async () => {
+      try {
+        const response = await getMyApplySummary(4, buttonIndex + 1);
+        setApplySummary(response.data);
+      } catch (error) {
+        console.error('Error fetching apply summary:', error);
+      }
+    };
+    fetchApplySummary();
+  }, [buttonIndex]);
 
   return (
     <div className={styles.container}>
       <Text as="h3" typography="heading3">
         팀 빌딩 현황
       </Text>
-      <ButtonToggleGroup
-        size="lg"
-        activeIndex={buttonIndex}
-        onToggle={setButtonIndex}
-        className={styles.buttonToggleGroup}>
-        {phases.map((phase, index) => {
-          const isUpcoming = index > currentPhaseIndex;
-
-          return (
-            <ButtonToggleGroup.ButtonToggleItem key={phase.label} disabled={isUpcoming}>
-              {isUpcoming ? `${phase.label} 공개 예정` : `${phase.label} (${phase.periodText || '기간 미정'})`}
-            </ButtonToggleGroup.ButtonToggleItem>
-          );
-        })}
-      </ButtonToggleGroup>
+      <TeamBuildingPhaseSelector onPhaseChange={setButtonIndex} activeIndex={buttonIndex} />
 
       {applySummary?.applies?.map((apply: any) => (
         <IdeaApplyListItem key={apply.apply_info.id} applySummary={apply} phase={buttonIndex + 1} />

--- a/src/pages/hackathon/teamBuilding/provider/ProviderPage.tsx
+++ b/src/pages/hackathon/teamBuilding/provider/ProviderPage.tsx
@@ -2,7 +2,30 @@ import styles from './styles.module.scss';
 import { Text } from '@goorm-dev/vapor-components';
 import TeamInformation from '../../../../components/hackathon/teamBuilding/TeamInformation';
 import ApplyStatusTable from '../../../../components/hackathon/teamBuilding/applyStatusTable/ApplyStatusTable';
+import TeamBuildingPhaseSelector from '../../../../components/hackathon/teamBuilding/TeamBuildingPhaseSelector';
+import { useEffect, useState } from 'react';
+import usePeriodStore from '../../../../store/usePeriodStore';
+import { getIdeaApplyStatus } from '../../../../api/users';
+
 export default function ProviderPage() {
+  const [buttonIndex, setButtonIndex] = useState(0);
+  const [applyStatus, setApplyStatus] = useState<any>(null);
+  // 현재 팀빌딩 기간 조회
+  const { fetchPeriodData } = usePeriodStore();
+
+  useEffect(() => {
+    fetchPeriodData();
+  }, []);
+
+  // 지원 현황 조회
+  useEffect(() => {
+    const fetchApplyStatus = async () => {
+      const response = await getIdeaApplyStatus(4, buttonIndex + 1);
+      setApplyStatus(response.data);
+    };
+    fetchApplyStatus();
+  }, [buttonIndex]);
+
   return (
     <div className={styles.container}>
       <div className={styles.teamInform}>
@@ -12,10 +35,18 @@ export default function ProviderPage() {
         <TeamInformation viewer={false} />
       </div>
       <div className={styles.applyStatus}>
-        <Text as="h3" typography="heading3" color="text-normal">
-          지원 현황
-        </Text>
-        <ApplyStatusTable />
+        <div className={styles.applyStatusHeader}>
+          <Text as="h3" typography="heading3" color="text-normal">
+            지원 현황
+          </Text>
+          <Text as="h4" typography="heading4" color="text-primary">
+            {applyStatus?.counts}명
+          </Text>
+        </div>
+
+        <TeamBuildingPhaseSelector onPhaseChange={setButtonIndex} activeIndex={buttonIndex} />
+
+        <ApplyStatusTable applicants={applyStatus} />
       </div>
     </div>
   );

--- a/src/pages/hackathon/teamBuilding/provider/styles.module.scss
+++ b/src/pages/hackathon/teamBuilding/provider/styles.module.scss
@@ -19,3 +19,10 @@
   align-items: flex-start;
   gap: var(--space-200);
 }
+
+.applyStatusHeader {
+  display: flex;
+  gap: var(--space-100);
+  align-items: center;
+  width: 100%;
+}

--- a/src/store/usePeriodStore.ts
+++ b/src/store/usePeriodStore.ts
@@ -14,14 +14,29 @@ interface PeriodState {
   phase1_period: string;
   phase2_period: string;
   phase3_period: string;
+  isTeamBuildingPeriod: () => boolean;
+  isConfirmationPeriod: () => boolean;
   fetchPeriodData: () => Promise<void>;
 }
 
-const usePeriodStore = create<PeriodState>((set) => ({
+const usePeriodStore = create<PeriodState>((set, get) => ({
   current_period: 'NONE',
   phase1_period: '',
   phase2_period: '',
   phase3_period: '',
+
+  // 팀 빌딩 기간인지 확인
+  isTeamBuildingPeriod: () => {
+    const state = get();
+    return ['PHASE1_TEAM_BUILDING', 'PHASE2_TEAM_BUILDING', 'PHASE3_TEAM_BUILDING'].includes(state.current_period);
+  },
+
+  // 확정 기간인지 확인
+  isConfirmationPeriod: () => {
+    const state = get();
+    return ['PHASE1_CONFIRMATION', 'PHASE2_CONFIRMATION', 'PHASE3_CONFIRMATION'].includes(state.current_period);
+  },
+
   fetchPeriodData: async () => {
     try {
       const response = await fetchPeriod();


### PR DESCRIPTION
## ⛅️ 작업 내용

- [x] provider 입장에서의 지원현황을 볼 수 있도록 api를 연결하였습니다.
- [x] 유저아이디, applyId를 통해 지원 확정할 수 있도록 api를 연결하였습니다.
- [x] 기간별 데이터를 전역상태관리하여 기간 별로 다르게 뜰 수 있도록 구현하였습니다.  
