### PR TITLE
[Fix/#119] 아이디어 등록 과정 수정

### DIFF
--- a/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
+++ b/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
@@ -39,9 +39,9 @@ export default function TeamPreferenceStep1({ formData, nextStep }: TeamPreferen
   }, []);
 
   // 파트 선택 시 step2에 있는 capacity 값 변경
-  const handleRoleChange = (role: 'pm' | 'pd' | 'fe' | 'be') => {
-    if (role === 'pm' || role === 'pd') {
-      if (formData.requirements[role]?.capacity === 1) {
+  const handleRoleChange = (role: 'PM' | 'PD' | 'FE' | 'BE') => {
+    if (role === 'PM' || role === 'PD') {
+      if (formData.requirements[role.toLowerCase()]?.capacity === 1) {
         setIsAlertVisible(true);
         return;
       }
@@ -58,7 +58,6 @@ export default function TeamPreferenceStep1({ formData, nextStep }: TeamPreferen
       content: formData.idea_info.content.trim() !== '',
       provider_role: formData.idea_info.provider_role !== '',
     };
-    console.log(formStatus);
     return Object.values(formStatus).every((value) => value === true);
   };
 
@@ -107,7 +106,7 @@ export default function TeamPreferenceStep1({ formData, nextStep }: TeamPreferen
               nullable={false}
               value={formData.idea_info.provider_role}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                handleRoleChange(e.target.id as 'pm' | 'pd' | 'fe' | 'be')
+                handleRoleChange(e.target.id as 'PM' | 'PD' | 'FE' | 'BE')
               }
             />
             {isAlertVisible && (

--- a/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep2.tsx
+++ b/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep2.tsx
@@ -37,8 +37,8 @@ export default function TeamPreferenceStep2({
             key={position.key}
             position={position}
             isDisabled={
-              ['pm', 'pd'].includes(formData.idea_info?.provider_role) &&
-              position.key === formData.idea_info?.provider_role
+              ['pm', 'pd'].includes(formData.idea_info?.provider_role.toLowerCase()) &&
+              position.key === formData.idea_info?.provider_role.toLowerCase()
             }
           />
         ))}

--- a/src/components/hackathon/ideaForm/FormRadio.tsx
+++ b/src/components/hackathon/ideaForm/FormRadio.tsx
@@ -14,10 +14,10 @@ export default function FormRadio({ label, nullable, value, onChange }: FormRadi
     <FormGroup>
       <FormLabel label={label} nullable={nullable} />
       <div className={styles.radioContainer}>
-        <Radio label="기획" id="pm" name="role" checked={value === 'pm'} onChange={onChange} />
-        <Radio label="디자인" id="pd" name="role" checked={value === 'pd'} onChange={onChange} />
-        <Radio label="프론트엔드" id="fe" name="role" checked={value === 'fe'} onChange={onChange} />
-        <Radio label="백엔드" id="be" name="role" checked={value === 'be'} onChange={onChange} />
+        <Radio label="기획" id="PM" name="role" checked={value === 'PM'} onChange={onChange} />
+        <Radio label="디자인" id="PD" name="role" checked={value === 'PD'} onChange={onChange} />
+        <Radio label="프론트엔드" id="FE" name="role" checked={value === 'FE'} onChange={onChange} />
+        <Radio label="백엔드" id="BE" name="role" checked={value === 'BE'} onChange={onChange} />
       </div>
     </FormGroup>
   );

--- a/src/components/hackathon/ideaForm/PositionForm.tsx
+++ b/src/components/hackathon/ideaForm/PositionForm.tsx
@@ -56,7 +56,7 @@ export default function PositionForm({ position, isDisabled }: PositionFormProps
       <FormDropdown
         label="필요 인원"
         nullable={false}
-        selectedValue={currentValue.capacity.toString()}
+        selectedValue={currentValue?.capacity?.toString() || '0'}
         placeholder="인원을 선택해주세요"
         // 직군에 따라 최대 팀원 수 다름
         options={Array.from({ length: getMaxCapacity(position.key) + 1 }, (_, i) => ({ id: i, name: i.toString() }))}

--- a/src/pages/hackathon/IdeaCreateEdit/TeamPreferenceForm.tsx
+++ b/src/pages/hackathon/IdeaCreateEdit/TeamPreferenceForm.tsx
@@ -27,11 +27,41 @@ export default function TeamPreferenceForm({ isEditMode, step }: TeamPreferenceF
         try {
           const response = await fetchIdeaDetailById(idea_id);
 
+          const mappedIdeaInfo = {
+            ...response.data.idea_info,
+            provider_role: response.data.provider_info.role,
+            idea_subject_id: response.data.idea_info.id,
+          };
+
+          // 현재 코드 매핑 필요
+          const mappedRequirements = {
+            pm: {
+              requirement: response.data.requirements.pm.requirement || '',
+              capacity: response.data.requirements.pm.max_count || 0,
+              required_tech_stacks: response.data.requirements.pm.required_tech_stacks || [],
+            },
+            pd: {
+              requirement: response.data.requirements.pd.requirement || '',
+              capacity: response.data.requirements.pd.max_count || 0,
+              required_tech_stacks: response.data.requirements.pd.required_tech_stacks || [],
+            },
+            fe: {
+              requirement: response.data.requirements.fe.requirement || '',
+              capacity: response.data.requirements.fe.max_count || 0,
+              required_tech_stacks: response.data.requirements.fe.required_tech_stacks || [],
+            },
+            be: {
+              requirement: response.data.requirements.be.requirement || '',
+              capacity: response.data.requirements.be.max_count || 0,
+              required_tech_stacks: response.data.requirements.be.required_tech_stacks || [],
+            },
+          };
+
           // Edit모드도 전역 관리
-          Object.entries(response.data.idea_info).forEach(([key, value]) => {
+          Object.entries(mappedIdeaInfo).forEach(([key, value]) => {
             updateIdeaInfo(key as keyof typeof idea_info, value);
           });
-          Object.entries(response.data.requirements).forEach(([key, value]) => {
+          Object.entries(mappedRequirements).forEach(([key, value]) => {
             updateRequirements(key as RequirementKey, value);
           });
         } catch (error) {


### PR DESCRIPTION
## 🔥 Related Issues

- close #119 

## ⛅️ 작업 내용
- [x] 수정모드의 subject_id의 필드명이 바뀌면서 생기는 오류 수정
- [ ] 수정모드일 때의 문제 -> 해당 내용은 detail에서 불러오는데 그 내용이 매번 컴포넌트 새로고침할 때마다 불러와져서 전역상태관리가 의미가 없어지는 문제 발생
- [x] 수정모드일 때 인원 선택 중 toString()으로 인한 타입오류
- [x] 등록모드일 때 인원이 꽉찼다면 disabled되는 부분 적용 안되는중
- [x] 등록모드일 때 provider_role이 소문자로 들어가서 오류나는 현상 수정

## ✅ PR Point

<!-- 무슨 이유로 어떻게 코드를 변경했는지 -->
<!-- 어떤 위험이나 우려가 발견되었는지(팀원이 알아야 할 것) -->
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 -->

수정모드의 전역상태관리는 조금 더 고민해보아야할 것 같습니다.

