### PR TITLE
[Refactor/#186] 6/18 발견한 QA 테스트

### DIFF
--- a/src/api/admin/idea.ts
+++ b/src/api/admin/idea.ts
@@ -2,7 +2,7 @@ import instance from '../instance';
 
 // 3.18 어드민 아이디어 주제 간단 리스트 조회
 export const fetchIdeaSubjects = async (generation: number) => {
-  const response = await instance.get(`/api/v1/admin/ideas/subjects?generation=${generation}`);
+  const response = await instance.get(`/api/v1/admins/idea-subjects/briefs?generation=${generation}`);
   return response.data;
 };
 

--- a/src/api/idea.ts
+++ b/src/api/idea.ts
@@ -116,3 +116,9 @@ export const applyIdea = async (
   });
   return response.data;
 };
+
+// 3.16 아이디어 삭제
+export const deleteIdea = async (idea_id: number) => {
+  const response = await instance.delete(`/api/v1/users/ideas/${idea_id}`);
+  return response.data;
+};

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -17,6 +17,8 @@ export const updateTeamInfo = async (generation: number, name: string) => {
 
 // 4.10 팀 빌딩 확정
 export const confirmTeamBuilding = async (generation: number) => {
-  const response = await instance.patch(`/api/v1/users/teams/status?generation=${generation}`);
+  const response = await instance.patch(`/api/v1/users/teams/status`, {
+    generation,
+  });
   return response.data;
 };

--- a/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
+++ b/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
@@ -22,6 +22,11 @@ export default function TeamPreferenceStep1({ formData, nextStep }: TeamPreferen
   const [isAlertVisible, setIsAlertVisible] = useState(false);
   const { updateIdeaInfo } = useIdeaFormStore();
 
+  // 페이지 이동 시 스크롤 초기화
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   // 아이디어 주제 조회
   useEffect(() => {
     const loadTopics = async () => {

--- a/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
+++ b/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
@@ -72,7 +72,7 @@ export default function TeamPreferenceStep1({ formData, nextStep }: TeamPreferen
   };
 
   // 이름으로 확인
-  const selectedTopic = topics.find((topic) => topic.name === formData.idea_info.subject);
+  const selectedTopic = topics.find((topic) => topic.id === formData.idea_info.idea_subject_id);
 
   return (
     <div className={styles.container}>

--- a/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep2.tsx
+++ b/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep2.tsx
@@ -4,6 +4,7 @@ import PositionForm from '../ideaForm/PositionForm';
 import BackLinkNavigation from '../common/BackLinkNavigation';
 import { InfoCircleIcon } from '@goorm-dev/vapor-icons';
 import { POSITIONS, RequirementKey } from '../../../constants/position';
+import { useEffect } from 'react';
 
 interface TeamPreferenceStep2Props {
   formData: any;
@@ -24,6 +25,11 @@ export default function TeamPreferenceStep2({
     name: value.name,
     index: value.index,
   }));
+
+  // 페이지 이동 시 스크롤 초기화
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/src/components/hackathon/ideaDetail/IdeaDetailHeader.tsx
+++ b/src/components/hackathon/ideaDetail/IdeaDetailHeader.tsx
@@ -48,7 +48,7 @@ export default function IdeaDetailHeader({
   const toggle = () => setOpen((prev) => !prev);
   const navigate = useNavigate();
   const breakpoint = useBreakPoint();
-  const { current_period } = usePeriodStore();
+  const { current_period, isTeamBuildingPeriod } = usePeriodStore();
   const { status, fetchUserStatus } = useAuthStore();
 
   // 사용자 상태 조회
@@ -56,7 +56,14 @@ export default function IdeaDetailHeader({
     fetchUserStatus();
   }, []);
 
+  // 아이디어 지원 이동
   const handleApplyIdea = () => {
+    if (!isTeamBuildingPeriod()) {
+      toast('팀 빌딩 지원 기간이 아닙니다.', {
+        type: 'danger',
+      });
+      return;
+    }
     if (status === UserStatus.APPLICANT || status === UserStatus.NONE) {
       navigate(`/hackathon/apply/${id}`);
     } else if (status === UserStatus.PROVIDER) {

--- a/src/components/hackathon/ideaDetail/IdeaDetailHeader.tsx
+++ b/src/components/hackathon/ideaDetail/IdeaDetailHeader.tsx
@@ -16,6 +16,7 @@ import useBreakPoint from '../../../hooks/useBreakPoint';
 import usePeriodStore from '../../../store/usePeriodStore';
 import useAuthStore from '../../../store/useAuthStore';
 import { UserStatus } from '../../../constants/role';
+import { deleteIdea } from '../../../api/idea';
 interface IdeaDetailHeaderProps {
   id: number;
   provider_id: number;
@@ -73,6 +74,19 @@ export default function IdeaDetailHeader({
     }
   };
 
+  // 아이디어 삭제
+  const handleDeleteIdea = async () => {
+    if (current_period === 'IDEA_SUBMISSION') {
+      await deleteIdea(id);
+      await fetchUserStatus(); // 사용자 상태 갱신
+      navigate('/hackathon');
+    } else {
+      toast('아이디어 삭제 기간이 아닙니다.', {
+        type: 'danger',
+      });
+    }
+  };
+
   return (
     <div className={styles.headerContainer}>
       <div className={styles.titleContainer}>
@@ -103,6 +117,7 @@ export default function IdeaDetailHeader({
                 <DropdownItem
                   color="danger"
                   className={styles.deleteItem}
+                  onClick={handleDeleteIdea}
                   disabled={current_period !== 'IDEA_SUBMISSION'}>
                   삭제하기
                 </DropdownItem>

--- a/src/components/hackathon/ideaForm/FormEditor.tsx
+++ b/src/components/hackathon/ideaForm/FormEditor.tsx
@@ -174,14 +174,6 @@ export default function FormEditor({
             italic,
             strikethrough,
             hr,
-            commands.group(
-              [commands.title1, commands.title2, commands.title3, commands.title4, commands.title5, commands.title6],
-              {
-                name: 'title',
-                groupName: 'title',
-                buttonProps: { 'aria-label': 'Insert title' },
-              },
-            ),
             commands.divider,
             commands.link,
             commands.quote,

--- a/src/components/signUp/SignUpCard.tsx
+++ b/src/components/signUp/SignUpCard.tsx
@@ -55,8 +55,8 @@ export default function SignUpCard() {
         navigate('/');
       }
     } catch (error: any) {
-      setErrorMessage(error.response.data.error?.message || '알 수 없는 오류가 발생했습니다.');
-      console.log(error.response.data.error?.message);
+      setErrorMessage('아이디 또는 비밀번호가 일치하지 않습니다.');
+      console.log(error.response.data);
     }
   }, [email, password, login, navigate]);
 

--- a/src/pages/hackathon/IdeaCreateEdit/TeamPreferenceForm.tsx
+++ b/src/pages/hackathon/IdeaCreateEdit/TeamPreferenceForm.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useIdeaFormStore } from '../../../store/useIdeaFormStore';
-import { createIdeaAPI, fetchIdeaDetailById, updateIdeaAPI } from '../../../api/idea';
+import { createIdeaAPI, fetchMyIdeaDetail, updateIdeaAPI } from '../../../api/idea';
 import TeamPreferenceStep1 from '../../../components/hackathon/IdeaCreateEdit/TeamPreferenceStep1';
 import TeamPreferenceStep2 from '../../../components/hackathon/IdeaCreateEdit/TeamPreferenceStep2';
 import { IDEA_ADD_ERROR_MESSAGES } from '../../../constants/errorMessage';
@@ -23,7 +23,7 @@ export default function TeamPreferenceForm({ isEditMode, step }: TeamPreferenceF
     if (isEditMode && idea_id) {
       const fetchData = async () => {
         try {
-          const response = await fetchIdeaDetailById(idea_id);
+          const response = await fetchMyIdeaDetail();
 
           const mappedIdeaInfo = {
             ...response.data.idea_info,

--- a/src/pages/hackathon/IdeaDetail/IdeaDetail.tsx
+++ b/src/pages/hackathon/IdeaDetail/IdeaDetail.tsx
@@ -19,6 +19,11 @@ export default function IdeaDetail() {
   const { idea_info, provider_info, requirements } = ideaDetail || {};
   const [isLoading, setIsLoading] = useState(true);
 
+  // 페이지 이동 시 스크롤 초기화
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   // 아이디어 조회
   useEffect(() => {
     setIsLoading(true);

--- a/src/pages/hackathon/IdeaDetail/IdeaDetail.tsx
+++ b/src/pages/hackathon/IdeaDetail/IdeaDetail.tsx
@@ -5,7 +5,7 @@ import styles from './styles.module.scss';
 import IdeaInfo from '../../../components/hackathon/ideaDetail/ideaDetailInfo/IdeaInfo';
 import TeamInfo from '../../../components/hackathon/ideaDetail/ideaDetailInfo/TeamInfo';
 import { addIdeaBookmark, fetchIdeaDetailById, fetchMyIdeaDetail } from '../../../api/idea';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import BackLinkNavigation from '../../../components/hackathon/common/BackLinkNavigation';
 import { toast } from '@goorm-dev/vapor-components';
 import IdeaHeaderSkeleton from '../../../components/hackathon/ideaDetail/skeletonLoading/IdeaHeaderSkeleton';
@@ -18,7 +18,7 @@ export default function IdeaDetail() {
   const [ideaDetail, setIdeaDetail] = useState<any>(null);
   const { idea_info, provider_info, requirements } = ideaDetail || {};
   const [isLoading, setIsLoading] = useState(true);
-
+  const navigate = useNavigate();
   // 페이지 이동 시 스크롤 초기화
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -31,7 +31,11 @@ export default function IdeaDetail() {
       try {
         const response = idea_id ? await fetchIdeaDetailById(idea_id) : await fetchMyIdeaDetail();
         setIdeaDetail(response.data);
-      } catch (error) {
+      } catch (error: any) {
+        toast('아이디어 조회 기간이 아닙니다.', {
+          type: 'danger',
+        });
+        navigate('/hackathon');
         console.error('Error fetching idea details:', error);
       } finally {
         setIsLoading(false);

--- a/src/pages/hackathon/IdeaList/IdeaList.tsx
+++ b/src/pages/hackathon/IdeaList/IdeaList.tsx
@@ -94,6 +94,11 @@ export default function IdeaList() {
   // 한 페이지당 보여질 페이지 수
   const projectsPerPage = 8;
 
+  // 페이지 이동 시 스크롤 초기화
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   // 기간 정보 갱신 및 사용자 상태 조회
   useEffect(() => {
     fetchPeriodData();

--- a/src/pages/hackathon/IdeaList/IdeaList.tsx
+++ b/src/pages/hackathon/IdeaList/IdeaList.tsx
@@ -281,27 +281,26 @@ export default function IdeaList() {
           </div>
         </div>
         {/* 팀 빌딩 기간인지에 따라 달라지는 뷰 */}
-        {isTeamBuilding ? (
-          ideaList.ideas.length === 0 ? (
+        {loading ? (
+          <IdeaListSkeleton />
+        ) : (
+          isTeamBuilding &&
+          (ideaList.ideas.length === 0 ? (
             <NoAccess heading1="아이디어가 없어요 :(" />
           ) : (
             <div className={styles.ideaListWrap}>
-              {loading ? (
-                <IdeaListSkeleton />
-              ) : (
-                ideas?.map((idea: any) => (
-                  <IdeaListItem
-                    key={idea.id}
-                    topic={idea.subject}
-                    title={idea.title}
-                    description={idea.summary}
-                    is_active={idea.is_active}
-                    is_bookmarked={idea.is_bookmarked}
-                    onClick={() => handleIdeaClick(idea.id)}
-                    onBookmarkToggle={() => handleBookmarkToggle(idea.id)}
-                  />
-                ))
-              )}
+              {ideas?.map((idea: any) => (
+                <IdeaListItem
+                  key={idea.id}
+                  topic={idea.subject}
+                  title={idea.title}
+                  description={idea.summary}
+                  is_active={idea.is_active}
+                  is_bookmarked={idea.is_bookmarked}
+                  onClick={() => handleIdeaClick(idea.id)}
+                  onBookmarkToggle={() => handleBookmarkToggle(idea.id)}
+                />
+              ))}
 
               <BasicPagination
                 page={page_info?.current_page}
@@ -311,10 +310,9 @@ export default function IdeaList() {
                 className={styles.basicPagination}
               />
             </div>
-          )
-        ) : (
-          <NoAccess heading1="아직 볼 수 없어요 :(" heading2="팀빌딩 기간 시작 후 오픈됩니다." />
+          ))
         )}
+        {!isTeamBuilding && <NoAccess heading1="아직 볼 수 없어요 :(" heading2="팀빌딩 기간 시작 후 오픈됩니다." />}
       </div>
     </div>
   );

--- a/src/pages/hackathon/teamBuilding/applicant/ApplicantPage.tsx
+++ b/src/pages/hackathon/teamBuilding/applicant/ApplicantPage.tsx
@@ -55,14 +55,16 @@ export default function ApplicantPage() {
       {isLoading ? (
         <IdeaApplyListSkeleton />
       ) : applySummary?.applies?.length > 0 ? (
-        applySummary?.applies?.map((apply: any) => (
-          <IdeaApplyListItem
-            key={apply.apply_info.id}
-            applySummary={apply}
-            onDeleteSuccess={fetchApplySummary}
-            applyIndex={applySummary?.applies?.indexOf(apply) + 1}
-          />
-        ))
+        [...applySummary.applies]
+          .sort((a, b) => a.apply_info.preference - b.apply_info.preference)
+          .map((apply: any) => (
+            <IdeaApplyListItem
+              key={apply.apply_info.id}
+              applySummary={apply}
+              onDeleteSuccess={fetchApplySummary}
+              applyIndex={apply.apply_info.preference}
+            />
+          ))
       ) : (
         <Text typography="body1">지원 내역이 없습니다.</Text>
       )}

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -29,6 +29,11 @@ export default function MyPage() {
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // 페이지 이동 시 스크롤 초기화
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   // 유저 / 내 정보 조회 구분
   useEffect(() => {
     const fetchUserInfo = async () => {

--- a/src/pages/myPage/MyPageEdit.tsx
+++ b/src/pages/myPage/MyPageEdit.tsx
@@ -131,9 +131,13 @@ export default function MyPageEdit() {
       await updateUserInfo(updatedData);
       updateProfileImage(uploadedImageUrl);
       navigate('/my-page');
-    } catch (error) {
+    } catch (error: any) {
       console.error('프로필 업데이트 실패:', error);
-      setErrorMessage('프로필 수정에 실패했습니다.');
+      if (error.response.data.error.code === 40011) {
+        setErrorMessage('자기소개는 필수로 입력해야 합니다.');
+      } else {
+        setErrorMessage('프로필 수정에 실패했습니다.');
+      }
     }
   };
 

--- a/src/pages/myPage/MyPageEdit.tsx
+++ b/src/pages/myPage/MyPageEdit.tsx
@@ -33,6 +33,11 @@ export default function MyPageEdit() {
   const { updateProfileImage } = useAuthStore();
   const [isLoading, setIsLoading] = useState(true);
 
+  // 페이지 이동 시 스크롤 초기화
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   // 기존 유저 정보 불러오기
   useEffect(() => {
     setIsLoading(true);


### PR DESCRIPTION
## 🔥 Related Issues

- #186 

## ⛅️ 작업 내용

- [x] 아이디어 등록 주제 선택 시 선택된 것처럼 뜰 수 있게끔
- [x] 아이디어 등록에서 Next Step누르면 맨위로 스크롤되도록
- [x] 아이디어 등록 후 맨 위 스크롤될 수 있도록 
- [x] 네트워크가 느릴 때 기본 로딩이 될 수 있도록
- [x] Detail을 라우팅으로 직접 id들어가려고 할 때 나타나는 뷰 처리 필요
- [x] 아이디어 삭제 안되고 있음
- [x] 아이디어 수정 시 '나의'아이디어로 가져올 수 있도록 수정
- [ ] 아이디어 수정 시 subject_id가 게시물 id가 똑같이 들어오는 현상 수정\
- [ ] 아이디어 수정 시 주제 누를 때 다른 값으로 안바뀜
- [x] 팀빌딩 확정 generation body로 바꾸기
- [x] 지원하기 누를 때 아이디어 지원 기간 아니면 문구 미리 띄우기(토스트로)
- [x] 지원했을 때 지망 제대로 뜨게끔 바꾸기
- [x] 로그인 창에서 문구 제대로 띄우기
- [x] Error 코드에 따라 자기소개 값 필수로 뜰 수있게끔 
- [x] 마이페이지 수정 후 스크롤 위로
- [x] 마크다운 에디터 title 부분 이상한 부분 수정
