### PR TITLE
[refactor/#236] 메시지 UX 통일 및 드래그앤드롭 안내 개선

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { reissueAPI } from './auth';
 import useAuthStore from '../store/useAuthStore';
 import { useNavigate } from 'react-router-dom';
+import { toast } from '@goorm-dev/vapor-components';
 const instance = axios.create({
   baseURL: import.meta.env.VITE_APP_BASE_URL,
   withCredentials: true,
@@ -58,7 +59,7 @@ instance.interceptors.response.use(
         isRefreshing = false;
         refreshSubscribers = [];
         useAuthStore.getState().resetToGuest(); // 로그인 풀리면 GUEST로 변경
-        alert('로그아웃 되었습니다. 다시 로그인해주세요.');
+        toast('로그아웃 되었습니다. 다시 로그인해주세요.', { type: 'danger' });
         if (navigate) {
           navigate('/login');
         }

--- a/src/components/admin/ideaManagement/topicModal/TopicModal.tsx
+++ b/src/components/admin/ideaManagement/topicModal/TopicModal.tsx
@@ -28,7 +28,9 @@ export const TopicModal = ({ isOpen, toggle }: { isOpen: boolean; toggle: () => 
           setTopics(res.data.idea_subjects.map((t: any) => ({ id: t.id, value: t.name, isEditing: false })));
         }
       } catch (err) {
-        console.error('조회 실패', err);
+        if (import.meta.env.DEV) {
+          console.log(err);
+        }
       }
     };
 
@@ -54,7 +56,9 @@ export const TopicModal = ({ isOpen, toggle }: { isOpen: boolean; toggle: () => 
       toast('주제 삭제에 실패했습니다. 이미 사용된 주제는 삭제할 수 없습니다.', {
         type: 'danger',
       });
-      console.error('주제 삭제 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
     }
   };
 

--- a/src/components/admin/participantList/form/UnivForm.tsx
+++ b/src/components/admin/participantList/form/UnivForm.tsx
@@ -55,7 +55,9 @@ export default function UnivForm({ mode, form, onChange, univId }: UnivFormProps
         })),
       );
     } catch (error) {
-      console.error('Failed to fetch users:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
     }
   };
 

--- a/src/components/admin/participantList/modal/PasswordResetModal.tsx
+++ b/src/components/admin/participantList/modal/PasswordResetModal.tsx
@@ -16,7 +16,9 @@ export const PasswordResetModal = ({ isOpen, toggle, password }: PasswordResetMo
         type: 'primary',
       });
     } catch (err) {
-      console.error('클립보드 복사 실패:', err);
+      if (import.meta.env.DEV) {
+        console.log(err);
+      }
     }
   };
 

--- a/src/components/admin/teamList/modal/TeamUpdateModal.tsx
+++ b/src/components/admin/teamList/modal/TeamUpdateModal.tsx
@@ -36,7 +36,9 @@ export default function TeamUpdateModal({ isOpen, toggle, teamId, onUpdate }: Te
             status: res.data.team_building ?? TeamBuildingStatus.RECRUITING,
           }); // 수정
         } catch (error) {
-          console.error(error);
+          if (import.meta.env.DEV) {
+            console.log(error);
+          }
         }
       };
       fetchTeamDetail();

--- a/src/components/admin/teamList/teamRow/TeamRow.tsx
+++ b/src/components/admin/teamList/teamRow/TeamRow.tsx
@@ -39,7 +39,9 @@ export const TeamRow = ({ team, onUpdate }: TeamRowProps) => {
       });
       onUpdate();
     } catch (error) {
-      console.error('팀 해체 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       toast('팀 해체에 실패했습니다.', {
         type: 'danger',
       });

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -21,7 +21,9 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    if (import.meta.env.DEV) {
+      console.log(error, errorInfo);
+    }
   }
 
   render() {

--- a/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
+++ b/src/components/hackathon/IdeaCreateEdit/TeamPreferenceStep1.tsx
@@ -42,8 +42,10 @@ export default function TeamPreferenceStep1({ formData, nextStep }: TeamPreferen
           name: topic.name,
         }));
         setTopics(activeTopics);
-      } catch (error) {
-        console.error('Error fetching idea subjects:', error);
+      } catch (error: any) {
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
       }
     };
 

--- a/src/components/hackathon/common/team/StackItem.tsx
+++ b/src/components/hackathon/common/team/StackItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import styles from './styles.module.scss';
 import { Tooltip } from '@goorm-dev/vapor-components';
 import { getStackName } from '../../../../constants/Stacks';
@@ -11,10 +11,6 @@ export default function StackItem({ skill }: StackItemProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const toggle = () => setTooltipOpen(!tooltipOpen);
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    console.log('ref:', ref.current);
-  }, []);
 
   return (
     <div

--- a/src/components/hackathon/ideaForm/FormEditor.tsx
+++ b/src/components/hackathon/ideaForm/FormEditor.tsx
@@ -209,7 +209,7 @@ export default function FormEditor({
             )}
 
             <Text typography="subtitle1" color="text-alternative">
-              이 곳을 클릭해서 이미지를 추가해 주세요.
+              클릭하거나 드래그 & 드롭으로 이미지를 추가할 수 있습니다.
             </Text>
           </div>
         )}

--- a/src/components/hackathon/ideaForm/FormTextarea.tsx
+++ b/src/components/hackathon/ideaForm/FormTextarea.tsx
@@ -11,6 +11,11 @@ interface FormTextareaProps {
 }
 
 export default function FormTextarea({ label, nullable, placeholder, value, onChange, disabled }: FormTextareaProps) {
+  const maxLength = 250;
+  const currentLength = value.length;
+  const isNearMax = currentLength >= maxLength * 0.8; // 80% 이상일 때
+  const isAtMax = currentLength >= maxLength; // 100%일 때
+
   return (
     <FormGroup>
       <Label className={styles.labelWrap}>
@@ -29,7 +34,13 @@ export default function FormTextarea({ label, nullable, placeholder, value, onCh
         value={value}
         onChange={onChange}
         disabled={disabled}
-        maxLength={255}></textarea>
+        maxLength={maxLength}
+      />
+      <div className={styles.characterCount}>
+        <Text typography="body3" color={isAtMax ? 'text-danger' : isNearMax ? 'text-warning' : 'text-hint'}>
+          {currentLength}/{maxLength}
+        </Text>
+      </div>
     </FormGroup>
   );
 }

--- a/src/components/hackathon/ideaForm/styles.module.scss
+++ b/src/components/hackathon/ideaForm/styles.module.scss
@@ -43,6 +43,13 @@
   }
 }
 
+.characterCount {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-050);
+  padding-right: var(--space-050);
+}
+
 .formContainer {
   display: flex;
   flex-direction: column;

--- a/src/components/hackathon/ideaForm/styles.module.scss
+++ b/src/components/hackathon/ideaForm/styles.module.scss
@@ -1,3 +1,5 @@
+@import '../../../style/mixin.scss';
+
 .labelWrap {
   display: flex;
   gap: var(--size-050);
@@ -171,6 +173,14 @@
   border: 1px solid var(--border-color);
   background: var(--background-alternative-01);
   cursor: pointer;
+  @include container-xs {
+    gap: var(--space-100);
+  }
+
+  @include container-sm {
+    gap: var(--space-050);
+  }
+
   &:hover {
     background: var(--secondary-hover);
   }

--- a/src/components/hackathon/teamBuilding/IdeaApplyListItem.tsx
+++ b/src/components/hackathon/teamBuilding/IdeaApplyListItem.tsx
@@ -67,8 +67,10 @@ export default function IdeaApplyListItem({ applySummary, onDeleteSuccess, apply
         type: 'primary',
       });
       onDeleteSuccess();
-    } catch (error) {
-      console.error('Error deleting apply:', error);
+    } catch (error: any) {
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       toast('지원 취소에 실패했습니다.', {
         type: 'danger',
       });

--- a/src/components/hackathon/teamBuilding/TeamInformation.tsx
+++ b/src/components/hackathon/teamBuilding/TeamInformation.tsx
@@ -48,7 +48,9 @@ export default function TeamInformation({ viewer, teamInfo }: TeamInformationPro
       await updateTeamInfo(GENERATION, teamName);
       setIsEditing(false);
     } catch (error) {
-      console.error('팀 이름 수정 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       setTeamName(teamName);
     }
   };

--- a/src/components/hackathon/teamBuilding/applyStatusTable/ApplyDecisionModal.tsx
+++ b/src/components/hackathon/teamBuilding/applyStatusTable/ApplyDecisionModal.tsx
@@ -49,8 +49,10 @@ export default function ApplyDecisionModal({
         }
         toggle();
         toast('지원을 거절했습니다.', { type: 'primary' });
-      } catch (error) {
-        console.error('Error rejecting apply:', error);
+      } catch (error: any) {
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
       }
     }
   };

--- a/src/components/layout/navbar/CustomNavbar.tsx
+++ b/src/components/layout/navbar/CustomNavbar.tsx
@@ -77,7 +77,9 @@ function CustomNavbar() {
         alert('아직 팀 빌딩을 진행하지 않았습니다.');
         break;
       default:
-        console.error('Unknown status:', currentStatus);
+        if (import.meta.env.DEV) {
+          console.log('Unknown status:', currentStatus);
+        }
         alert('알 수 없는 오류가 발생했습니다.');
     }
   };

--- a/src/components/layout/navbar/CustomNavbar.tsx
+++ b/src/components/layout/navbar/CustomNavbar.tsx
@@ -14,6 +14,7 @@ import {
   Nav,
   NavItem,
   NavLink,
+  toast,
 } from '@goorm-dev/vapor-components';
 import { useNavigate } from 'react-router-dom';
 import useAuthStore from '../../../store/useAuthStore';
@@ -74,13 +75,13 @@ function CustomNavbar() {
         navigate('/team/applicant');
         break;
       case UserStatus.NONE:
-        alert('아직 팀 빌딩을 진행하지 않았습니다.');
+        toast('아직 팀 빌딩을 진행하지 않았습니다.', { type: 'danger' });
         break;
       default:
         if (import.meta.env.DEV) {
           console.log('Unknown status:', currentStatus);
         }
-        alert('알 수 없는 오류가 발생했습니다.');
+        toast('알 수 없는 오류가 발생했습니다.', { type: 'danger' });
     }
   };
 
@@ -93,7 +94,7 @@ function CustomNavbar() {
     if (currentStatus === UserStatus.PROVIDER || currentStatus === UserStatus.MEMBER) {
       navigate('/team/my-team');
     } else {
-      alert('아직 팀 빌딩을 진행하지 않았습니다.');
+      toast('아직 팀 빌딩을 진행하지 않았습니다.', { type: 'danger' });
     }
   };
 

--- a/src/components/layout/navbar/CustomNavbar.tsx
+++ b/src/components/layout/navbar/CustomNavbar.tsx
@@ -182,11 +182,11 @@ function CustomNavbar() {
 
           {isLoggedIn ? (
             <Dropdown nav isOpen={isMyPageOpened} toggle={() => setIsMyPageOpened((prev) => !prev)}>
-              <DropdownToggle nav className={styles.grayCircle}>
+              <DropdownToggle nav className={styles.profileCircle}>
                 {profileImg ? (
                   <img src={profileImg} alt="profile" className={styles.profileImg} />
                 ) : (
-                  <Avatar name="미르미" />
+                  <Avatar name="Admin" />
                 )}
               </DropdownToggle>
               <DropdownMenu right>

--- a/src/components/layout/navbar/customNavbar.module.scss
+++ b/src/components/layout/navbar/customNavbar.module.scss
@@ -76,26 +76,24 @@
   }
 }
 
-.grayCircle {
-  width: 2rem;
-  height: 2rem;
-  background-color: var(--gray-200);
-  border-radius: 1.25rem;
-  margin-left: -0.1rem;
-
-  &:hover {
-    background-color: var(--gray-200) !important;
+.profileCircle {
+  @include container-xs {
+    padding: 0.5625rem 1rem !important;
   }
-
-  &:focus {
-    background-color: var(--gray-200) !important;
+  @include container-lg {
+    padding: 0 !important;
   }
-  padding: 0 !important;
 }
 
 .dropdownToggle {
+  @include container-xs {
+    padding: 0.5625rem 1rem !important;
+  }
+  @include container-lg {
+    padding: 0 0.5rem !important;
+  }
   border: none !important;
-  padding: 0.5625rem 0.5rem !important;
+
   font-size: 0.875rem;
   line-height: 1.375rem;
   color: var(--text-alternative);
@@ -110,19 +108,25 @@
 }
 
 .dropdownToggleWhite {
-  border: none !important;
-  padding: 0.5625rem 0.5rem !important;
-  font-size: 0.875rem;
-  line-height: 1.375rem;
-  color: var(--gray-000);
-  height: var(--dimension-400) !important;
-  font-weight: 500;
-  background: none;
-
-  &:hover {
-    background: var(--gray-400-transparent-16);
-    outline: 0;
+  @include container-xs {
+    border: none !important;
+    padding: 0.5625rem 1rem !important;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+    height: var(--dimension-400) !important;
+    font-weight: 500;
+    background: none;
+    &:hover {
+      background: var(--gray-400-transparent-16);
+      outline: 0;
+    }
+  }
+  @include container-lg {
     color: var(--gray-000);
+
+    &:hover {
+      color: var(--gray-000);
+    }
   }
 }
 

--- a/src/components/searchUniv/searchCard.module.scss
+++ b/src/components/searchUniv/searchCard.module.scss
@@ -7,15 +7,26 @@
   justify-content: center;
   background-color: var(--gray-050);
   border-radius: 1.25rem;
-  margin-top: 8.37rem;
-  margin-bottom: 12.5rem;
+  width: 38.7rem;
+  margin: 8.37rem auto 12.5rem;
+  padding: var(--space-700) 5rem var(--space-500) 5rem;
 
   @include container-xs {
+    width: 20.75rem;
     padding: var(--space-500) var(--space-250);
   }
 
   @include container-sm {
+    width: 28.625rem;
     padding: var(--space-500) var(--space-500);
+  }
+
+  @include container-md {
+    width: 38.7rem;
+  }
+
+  @include container-lg {
+    padding: var(--space-700);
   }
 }
 

--- a/src/components/signUp/SignUpCard.tsx
+++ b/src/components/signUp/SignUpCard.tsx
@@ -55,7 +55,9 @@ export default function SignUpCard() {
         navigate('/');
       }
     } catch (error: any) {
-      console.error('로그인 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       if (error.response.data?.error?.code === 40100) {
         setErrorMessage('아이디 또는 비밀번호가 일치하지 않습니다.');
       } else {

--- a/src/hooks/useS3Upload.ts
+++ b/src/hooks/useS3Upload.ts
@@ -41,8 +41,10 @@ export function useS3Upload() {
 
       const uploadedUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${fileName}`;
       return uploadedUrl;
-    } catch (error) {
-      console.error('S3 Upload Error:', error);
+    } catch (error: any) {
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       setError('이미지 업로드 실패');
       return null;
     } finally {

--- a/src/pages/admin/period/teamBuildingPeriod/TeamBuildingPeriodPage.tsx
+++ b/src/pages/admin/period/teamBuildingPeriod/TeamBuildingPeriodPage.tsx
@@ -56,8 +56,10 @@ export default function TeamBuildingPeriodPage() {
       toast('기간 설정이 완료되었습니다.', {
         type: 'primary',
       });
-    } catch (error) {
-      console.error(error);
+    } catch (error: any) {
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       toast('기간 설정에 실패했습니다.', {
         type: 'danger',
       });
@@ -117,8 +119,10 @@ export default function TeamBuildingPeriodPage() {
           startDate: formatDateInput(data.hackathon_start),
           endDate: formatDateInput(data.hackathon_end),
         });
-      } catch (error) {
-        console.error(error);
+      } catch (error: any) {
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
         toast('기간 조회에 실패했습니다.', {
           type: 'error',
         });

--- a/src/pages/admin/teamListAdmin/TeamList.tsx
+++ b/src/pages/admin/teamListAdmin/TeamList.tsx
@@ -56,7 +56,9 @@ export default function TeamList() {
         type: 'primary',
       });
     } catch (error: any) {
-      console.error(error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       toast('팀 번호 부여에 실패했습니다.', {
         type: 'danger',
       });

--- a/src/pages/admin/teamManagement/TeamManagement.tsx
+++ b/src/pages/admin/teamManagement/TeamManagement.tsx
@@ -27,8 +27,10 @@ export default function TeamManagement() {
         try {
           const res = await fetchTeamMemberSummaryListAPI(Number(team_id));
           setTeamMemberSummaryList(res.data.members);
-        } catch (error) {
-          console.error(error);
+        } catch (error: any) {
+          if (import.meta.env.DEV) {
+            console.log(error);
+          }
         }
       };
       fetchTeamMemberSummaryList();

--- a/src/pages/hackathon/IdeaApply/IdeaApply.tsx
+++ b/src/pages/hackathon/IdeaApply/IdeaApply.tsx
@@ -96,7 +96,7 @@ export default function IdeaApply() {
           <FormTextarea
             label="함께 하고 싶은 이유를 작성해주세요"
             nullable={false}
-            placeholder="n자 이내로 작성해주세요"
+            placeholder="250자 이내로 작성해주세요"
             value={reason}
             onChange={(e) => setReason(e.target.value)}
           />

--- a/src/pages/hackathon/IdeaApply/IdeaApply.tsx
+++ b/src/pages/hackathon/IdeaApply/IdeaApply.tsx
@@ -42,7 +42,9 @@ export default function IdeaApply() {
           const serverMessage = error.response.data.error?.code;
           setErrorMessage(serverMessage || '알 수 없는 오류가 발생했습니다.');
         } else {
-          console.error('Error fetching preferences:', error);
+          if (import.meta.env.DEV) {
+            console.log(error);
+          }
         }
       }
     };
@@ -63,7 +65,9 @@ export default function IdeaApply() {
         const errorCode = error.response.data?.error?.code;
         setErrorMessage(IDEA_APPLY_ERROR_MESSAGES[errorCode] || '알 수 없는 오류가 발생했습니다.');
       } else {
-        console.error('Error applying idea:', error);
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
       }
     }
   };

--- a/src/pages/hackathon/IdeaCreateEdit/TeamPreferenceForm.tsx
+++ b/src/pages/hackathon/IdeaCreateEdit/TeamPreferenceForm.tsx
@@ -64,8 +64,10 @@ export default function TeamPreferenceForm({ isEditMode, step }: TeamPreferenceF
           Object.entries(mappedRequirements).forEach(([key, value]) => {
             updateRequirements(key as PositionLowerKey, value);
           });
-        } catch (error) {
-          console.error('Error fetching idea details:', error);
+        } catch (error: any) {
+          if (import.meta.env.DEV) {
+            console.log(error);
+          }
         }
       };
       fetchData();
@@ -98,7 +100,9 @@ export default function TeamPreferenceForm({ isEditMode, step }: TeamPreferenceF
         const serverMessage = error.response.data.error?.code;
         setErrorMessage(IDEA_ADD_ERROR_MESSAGES[serverMessage] || '알 수 없는 오류가 발생하였습니다.');
       } else {
-        console.error('Error submitting form:', error);
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
       }
     }
   };

--- a/src/pages/hackathon/IdeaDetail/IdeaDetail.tsx
+++ b/src/pages/hackathon/IdeaDetail/IdeaDetail.tsx
@@ -53,7 +53,9 @@ export default function IdeaDetail() {
           type: 'danger',
         });
         navigate('/hackathon');
-        console.error('Error fetching idea details:', error);
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
       } finally {
         setIsLoading(false);
       }
@@ -87,8 +89,10 @@ export default function IdeaDetail() {
           type: 'primary',
         });
       }
-    } catch (error) {
-      console.error('Error toggling bookmark:', error);
+    } catch (error: any) {
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
 
       setIdeaDetail((prevState: any) => ({
         ...prevState,

--- a/src/pages/hackathon/IdeaList/IdeaList.tsx
+++ b/src/pages/hackathon/IdeaList/IdeaList.tsx
@@ -130,8 +130,10 @@ export default function IdeaList() {
             }));
             setHackathonTopics([{ id: 0, name: '전체 주제' }, ...activeTopics]); // "전체" 옵션 추가
           }
-        } catch (error) {
-          console.error('Error fetching idea subjects:', error);
+        } catch (error: any) {
+          if (import.meta.env.DEV) {
+            console.log(error);
+          }
         }
       };
       loadTopics();
@@ -175,8 +177,10 @@ export default function IdeaList() {
           setMaxIdeaNumber(response.data.max_idea_number || 0);
           setCurrentIdeaNumber(response.data.current_idea_number || 0);
         }
-      } catch (error) {
-        console.error('Error fetching ideas:', error);
+      } catch (error: any) {
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
       } finally {
         setIdeasLoading(false);
       }
@@ -262,7 +266,9 @@ export default function IdeaList() {
         });
       }
     } catch (error: any) {
-      console.error('Error toggling bookmark:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       if (error.response) {
         const errorCode = error.response.data.error?.code;
         if (errorCode === 40013) {

--- a/src/pages/hackathon/teamBuilding/applicant/ApplicantPage.tsx
+++ b/src/pages/hackathon/teamBuilding/applicant/ApplicantPage.tsx
@@ -29,8 +29,10 @@ export default function ApplicantPage() {
         const response = await getMyApplySummary(GENERATION, buttonIndex + 1);
         setApplySummary(response.data);
       }
-    } catch (error) {
-      console.error('Error fetching apply summary:', error);
+    } catch (error: any) {
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       setApplySummary(null);
     } finally {
       setIsApplySummaryLoading(false);

--- a/src/pages/hackathon/teamBuilding/myTeam/MyTeamPage.tsx
+++ b/src/pages/hackathon/teamBuilding/myTeam/MyTeamPage.tsx
@@ -9,6 +9,7 @@ import { confirmTeamBuilding, getTeamInfo } from '../../../../api/teams';
 import { GENERATION } from '../../../../constants/common';
 import TeamInformationSkeleton from '../../../../components/hackathon/teamBuilding/skeletonLoading/TeamInformationSkeleton';
 import { TeamInfo } from '../../../../types/user/team';
+import { TEAM_BUILDING_CONFIRM_ERROR_MESSAGES } from '../../../../constants/errorMessage';
 
 export default function ApplicantTeamPage() {
   const { status } = useAuthStore();
@@ -24,7 +25,9 @@ export default function ApplicantTeamPage() {
       const res = await getTeamInfo(GENERATION);
       setTeamInfo(res.data);
     } catch (error: any) {
-      console.error('팀 정보 불러오기 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       toast('팀 정보 불러오기 실패', { type: 'danger' });
     } finally {
       setIsLoading(false);
@@ -49,11 +52,18 @@ export default function ApplicantTeamPage() {
       });
       toggle();
       fetchTeamInfo();
-    } catch (error) {
-      console.error('팀 빌딩 확정 실패:', error);
-      toast('팀 빌딩 확정에 실패했습니다. 팀 빌딩 조건을 다시 확인해주세요.', {
-        type: 'danger',
-      });
+    } catch (error: any) {
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
+      const errorCode = error.response.data?.error?.code;
+      toast(
+        TEAM_BUILDING_CONFIRM_ERROR_MESSAGES[errorCode] ||
+          '팀 빌딩 확정에 실패했습니다. 팀 빌딩 조건을 다시 확인해주세요.',
+        {
+          type: 'danger',
+        },
+      );
     }
   };
 

--- a/src/pages/hackathon/teamBuilding/provider/ProviderPage.tsx
+++ b/src/pages/hackathon/teamBuilding/provider/ProviderPage.tsx
@@ -55,7 +55,9 @@ export default function ProviderPage() {
         setApplyStatus(response.data);
       }
     } catch (error) {
-      console.error('지원 현황 불러오기 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       setApplyStatus({ counts: 0, applies: [] });
     } finally {
       setIsApplyStatusLoading(false);
@@ -74,7 +76,9 @@ export default function ProviderPage() {
         setCurrentPhaseApplyStatus(response.data);
       }
     } catch (error) {
-      console.error('지원 현황 불러오기 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       setCurrentPhaseApplyStatus({ counts: 0, applies: [] });
     } finally {
       setIsApplyStatusLoading(false);
@@ -116,7 +120,9 @@ export default function ProviderPage() {
         setTeamInfo(res.data);
       }
     } catch (error: any) {
-      console.error('팀 정보 불러오기 실패:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       toast('팀 정보 불러오기 실패', { type: 'danger' });
     } finally {
       setIsTeamInfoLoading(false);

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -50,7 +50,9 @@ export default function MyPage() {
           setUserInfo(response.data);
         }
       } catch (error) {
-        console.error('사용자 정보 조회 실패:', error);
+        if (import.meta.env.DEV) {
+          console.log(error);
+        }
         setUserInfo(null);
       } finally {
         setIsLoading(false);

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -56,7 +56,9 @@ const useAuthStore = create<AuthStore>((set) => ({
         img_url: img_url || null,
       });
     } catch (error) {
-      console.error('Login failed', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       throw error;
     }
   },
@@ -81,7 +83,9 @@ const useAuthStore = create<AuthStore>((set) => ({
         type: 'primary',
       });
     } catch (error: any) {
-      console.error('Logout error', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       shouldClearCookies = true;
     }
 
@@ -120,7 +124,9 @@ const useAuthStore = create<AuthStore>((set) => ({
 
       set({ status: parsedStatus, role: parsedRole, img_url: parsedImgUrl, isFetched: true });
     } catch (error) {
-      console.error('Error fetching user status:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       set({ isFetched: true });
       throw error;
     }

--- a/src/store/usePeriodStore.ts
+++ b/src/store/usePeriodStore.ts
@@ -93,7 +93,9 @@ const usePeriodStore = create<PeriodState>((set, get) => ({
         isFetched: true,
       });
     } catch (error) {
-      console.error('Error fetching period:', error);
+      if (import.meta.env.DEV) {
+        console.log(error);
+      }
       set({ isLoading: false, isFetched: true });
     }
   },


### PR DESCRIPTION
## 🔥 Related Issues

- close #236 

## ⛅️ 작업 내용

- ♻️ **Refactor**: 드래그 앤 드롭으로도 추가 가능하다는 안내 문구 명시  
- ♻️ **Refactor**: 콘솔 제거 및 팀빌딩 확정 시 메시지 노출 확대  
- ♻️ **Refactor**: toast와 기본 alert 메시지 통일  
- ♻️ **Refactor**: 네브바 흰 배경일 때 요소가 안 보이는 문제 수정  
- ♻️ **Refactor**: "나의 유니브 찾아보기" 페이지 내용 수정  
- ♻️ **Refactor**: 텍스트 에리어에 `maxLength` 및 안내 문구 추가  


